### PR TITLE
fix: Improve Dockerfile build commands for efficiency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ ARG OE_CORE_VERSION=30140cb9354fa535f68fab58e73b76f0cca342e4
 ENV OE_CORE_VERSION=${OE_CORE_VERSION}
 
 # Extract systemd and apply patches
-RUN cd /sources/downloads && tar -xvf systemd-${SYSTEMD_VERSION}.tar.gz && \
+RUN cd /sources/downloads && tar -xf systemd-${SYSTEMD_VERSION}.tar.gz && \
     mv systemd-${SYSTEMD_VERSION} systemd
 RUN cd /sources/downloads && git clone https://github.com/openembedded/openembedded-core && \
     cd openembedded-core && \
@@ -183,10 +183,10 @@ RUN mkdir /sources && \
    cd /sources && \
    wget https://busybox.net/downloads/busybox-${BUSYBOX_VERSION}.tar.bz2 
 
-RUN cd /sources && tar -xvf busybox-${BUSYBOX_VERSION}.tar.bz2 && \
+RUN cd /sources && tar -xf busybox-${BUSYBOX_VERSION}.tar.bz2 && \
     cd busybox-${BUSYBOX_VERSION} && \
-    make distclean && \
-    make ARCH="${ARCH}" defconfig && \
+    make -s distclean && \
+    make -s ARCH="${ARCH}" defconfig && \
     sed -i 's/\(CONFIG_\)\(.*\)\(INETD\)\(.*\)=y/# \1\2\3\4 is not set/g' .config && \
     sed -i 's/\(CONFIG_IFPLUGD\)=y/# \1 is not set/' .config && \
     sed -i 's/\(CONFIG_FEATURE_WTMP\)=y/# \1 is not set/' .config && \
@@ -194,27 +194,26 @@ RUN cd /sources && tar -xvf busybox-${BUSYBOX_VERSION}.tar.bz2 && \
     sed -i 's/\(CONFIG_UDPSVD\)=y/# \1 is not set/' .config && \
     sed -i 's/\(CONFIG_TCPSVD\)=y/# \1 is not set/' .config && \
     sed -i 's/\(CONFIG_TC\)=y/# \1 is not set/' .config && \
-    make ARCH="${ARCH}" CROSS_COMPILE="${TARGET}-" && \
-    make ARCH="${ARCH}" CROSS_COMPILE="${TARGET}-" CONFIG_PREFIX="/sysroot" install
+    make -s ARCH="${ARCH}" CROSS_COMPILE="${TARGET}-" -j${JOBS} && \
+    make -s ARCH="${ARCH}" CROSS_COMPILE="${TARGET}-" -j${JOBS} CONFIG_PREFIX="/sysroot" install
 
 ###
 ### MUSL
 ###
 FROM stage0 AS musl-stage0
-
 ARG MUSL_VERSION=1.2.5
 ENV MUSL_VERSION=${MUSL_VERSION}
 
 RUN wget http://musl.libc.org/releases/musl-${MUSL_VERSION}.tar.gz && \
-    tar -xvf musl-${MUSL_VERSION}.tar.gz && \
+    tar -xf musl-${MUSL_VERSION}.tar.gz && \
     cd musl-${MUSL_VERSION} && \
-    ./configure \
+    ./configure --disable-warnings \
       CROSS_COMPILE=${TARGET}- \
       --prefix=/usr \
       --disable-static \
       --target=${TARGET} && \
-      make -j${JOBS} && \
-      DESTDIR=/sysroot make -j${JOBS} install
+      make -s -j${JOBS} && \
+      DESTDIR=/sysroot make -s -j${JOBS} install
 
 ###
 ### GCC
@@ -232,18 +231,17 @@ RUN wget http://mirror.netcologne.de/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSIO
 RUN wget http://mirror.netcologne.de/gnu/gmp/gmp-${GMP_VERSION}.tar.bz2
 RUN wget http://mirror.netcologne.de/gnu/mpc/mpc-${MPC_VERSION}.tar.gz
 RUN wget http://mirror.netcologne.de/gnu/mpfr/mpfr-${MPFR_VERSION}.tar.bz2
-RUN tar -xvf gcc-${GCC_VERSION}.tar.xz
-RUN tar -xvf gmp-${GMP_VERSION}.tar.bz2
-RUN tar -xvf mpc-${MPC_VERSION}.tar.gz
-RUN tar -xvf mpfr-${MPFR_VERSION}.tar.bz2
+RUN tar -xf gcc-${GCC_VERSION}.tar.xz
+RUN tar -xf gmp-${GMP_VERSION}.tar.bz2
+RUN tar -xf mpc-${MPC_VERSION}.tar.gz
+RUN tar -xf mpfr-${MPFR_VERSION}.tar.bz2
 
 RUN <<EOT bash
     mv -v mpfr-${MPFR_VERSION} gcc-${GCC_VERSION}/mpfr
     mv -v mpc-${MPC_VERSION} gcc-${GCC_VERSION}/mpc
     mv -v gmp-${GMP_VERSION} gcc-${GCC_VERSION}/gmp
     mkdir -p /sysroot/usr/include
-    cd gcc-${GCC_VERSION} && mkdir -v build && cd build && ls -liah /gcc-${GCC_VERSION}/mpfr/src/ && \
-    ../configure \
+    cd gcc-${GCC_VERSION} && mkdir -v build && cd build && ../configure --quiet \
         --prefix=/usr \
         --build=${BUILD_ARCH} \
         --host=${TARGET} \
@@ -256,8 +254,8 @@ RUN <<EOT bash
         --disable-libmudflap \
         --disable-multilib \
         --disable-libsanitizer && \
-        make ARCH="${ARCH}" CROSS_COMPILE="${TARGET}-" -j${JOBS} && \
-        make ARCH="${ARCH}" CROSS_COMPILE="${TARGET}-" DESTDIR=/sysroot install ;
+        make -s ARCH="${ARCH}" CROSS_COMPILE="${TARGET}-" -j${JOBS} && \
+        make -s ARCH="${ARCH}" CROSS_COMPILE="${TARGET}-" DESTDIR=/sysroot install ;
 EOT
 
 ###
@@ -272,12 +270,12 @@ RUN mkdir /sources && \
    cd /sources && \
    wget https://mirror.netcologne.de/gnu/make/make-${MAKE_VERSION}.tar.gz
 
-RUN cd /sources && tar -xvf make-${MAKE_VERSION}.tar.gz && \
+RUN cd /sources && tar -xf make-${MAKE_VERSION}.tar.gz && \
     cd make-${MAKE_VERSION} && \
-    ./configure --prefix=/usr \
+    ./configure --quiet --prefix=/usr \
     --build=${BUILD_ARCH} --host=${TARGET} && \
-    make -j${JOBS} && \
-    make -j${JOBS} DESTDIR=/sysroot install
+    make -s -j${JOBS} && \
+    make -s -j${JOBS} DESTDIR=/sysroot install
 
 
 ###
@@ -290,12 +288,12 @@ ENV BINUTILS_VERSION=${BINUTILS_VERSION}
 
 RUN <<EOT bash
     wget http://mirror.easyname.at/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.xz
-    tar -xvf binutils-${BINUTILS_VERSION}.tar.xz
+    tar -xf binutils-${BINUTILS_VERSION}.tar.xz
 EOT
 
 RUN <<EOT bash
     cd binutils-${BINUTILS_VERSION} && 
-    ./configure \
+    ./configure --quiet \
        --prefix=/usr \
        --build=${BUILD_ARCH} \
        --host=${TARGET} \
@@ -304,8 +302,8 @@ RUN <<EOT bash
        --disable-nls \
        --disable-multilib \
        --enable-shared && \
-       make -j${JOBS} && \
-       make DESTDIR=/sysroot install ;
+       make -s -j${JOBS} && \
+       make -s -j${JOBS} DESTDIR=/sysroot install ;
 EOT
 
 ## This is a hack to avoid to need the kernel headers to compile things like busybox
@@ -327,23 +325,23 @@ COPY --from=skeleton /sysroot /skeleton
 
 ## GCC
 COPY --from=gcc-stage0 /sysroot /gcc
-RUN rsync -aHAX --keep-dirlinks  /gcc/. /skeleton
+RUN rsync -aHAX --keep-dirlinks /gcc/. /skeleton
 
 ## MUSL
 COPY --from=musl-stage0 /sysroot /musl
-RUN rsync -aHAX --keep-dirlinks  /musl/. /skeleton/
+RUN rsync -aHAX --keep-dirlinks /musl/. /skeleton/
 
 ## BUSYBOX
 COPY --from=busybox-stage0 /sysroot /busybox
-RUN rsync -aHAX --keep-dirlinks  /busybox/. /skeleton/
+RUN rsync -aHAX --keep-dirlinks /busybox/. /skeleton/
 
 ## Make
 COPY --from=make-stage0 /sysroot /make
-RUN rsync -aHAX --keep-dirlinks  /make/. /skeleton/
+RUN rsync -aHAX --keep-dirlinks /make/. /skeleton/
 
 ## Binutils
 COPY --from=binutils-stage0 /sysroot /binutils
-RUN rsync -aHAX --keep-dirlinks  /binutils/. /skeleton/
+RUN rsync -aHAX --keep-dirlinks /binutils/. /skeleton/
 
 ## This is a hack to avoid to need the kernel headers to compile things like busybox
 COPY --from=alpine-hack /usr/include/linux /linux
@@ -378,7 +376,7 @@ FROM stage1 AS test1
 
 RUN ls -liah /
 RUN gcc --version
-RUN make --version
+RUN make -s --version
 
 # This is a test to check if gcc is working
 COPY ./tests/gcc/test.c test.c
@@ -398,13 +396,13 @@ ARG MUSL_VERSION=1.2.5
 ENV MUSL_VERSION=${MUSL_VERSION}
 
 RUN wget http://musl.libc.org/releases/musl-${MUSL_VERSION}.tar.gz && \
-    tar -xvf musl-${MUSL_VERSION}.tar.gz && \
+    tar -xf musl-${MUSL_VERSION}.tar.gz && \
     cd musl-${MUSL_VERSION} && \
     ./configure \
       --prefix=/usr \
       --disable-static && \
-      make -j${JOBS} && \
-      DESTDIR=/sysroot make -j${JOBS} install
+      make -s -j${JOBS} && \
+      DESTDIR=/sysroot make -s -j${JOBS} install
 
 ## pkgconfig
 FROM stage1 AS pkgconfig
@@ -414,14 +412,14 @@ ENV PKGCONFIG_VERSION=${PKGCONFIG_VERSION}
 
 COPY --from=sources-downloader /sources/downloads/pkgconf-${PKGCONFIG_VERSION}.tar.xz /sources/
 
-RUN mkdir -p /sources && cd /sources && tar -xvf pkgconf-${PKGCONFIG_VERSION}.tar.xz && mv pkgconf-${PKGCONFIG_VERSION} pkgconfig && \
-    cd pkgconfig && mkdir -p /pkgconfig && ./configure ${COMMON_ARGS} --disable-dependency-tracking --prefix=/usr --sysconfdir=/etc \
+RUN mkdir -p /sources && cd /sources && tar -xf pkgconf-${PKGCONFIG_VERSION}.tar.xz && mv pkgconf-${PKGCONFIG_VERSION} pkgconfig && \
+    cd pkgconfig && mkdir -p /pkgconfig && ./configure --quiet ${COMMON_ARGS} --disable-dependency-tracking --prefix=/usr --sysconfdir=/etc \
     --mandir=/usr/share/man \
     --infodir=/usr/share/info \
     --localstatedir=/var \
     --with-pkg-config-dir=/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig && \
-    make && \
-    make DESTDIR=/pkgconfig install && make install && ln -s pkgconf /pkgconfig/usr/bin/pkg-config
+    make -s -j${JOBS} && \
+    make -s -j${JOBS} DESTDIR=/pkgconfig install && make -s -j${JOBS} install && ln -s pkgconf /pkgconfig/usr/bin/pkg-config
 
 ## autoconf
 FROM stage1 AS autoconf
@@ -430,9 +428,9 @@ ARG AUTOCONF_VERSION=2.71
 ENV AUTOCONF_VERSION=${AUTOCONF_VERSION}
 
 RUN mkdir /sources && cd /sources && wget http://mirror.easyname.at/gnu/autoconf/autoconf-${AUTOCONF_VERSION}.tar.xz && \
-    tar -xvf autoconf-${AUTOCONF_VERSION}.tar.xz && mv autoconf-${AUTOCONF_VERSION} autoconf && \
-    cd autoconf && mkdir -p /autoconf && ./configure ${COMMON_ARGS} && make DESTDIR=/autoconf && \
-    make DESTDIR=/autoconf install && make install
+    tar -xf autoconf-${AUTOCONF_VERSION}.tar.xz && mv autoconf-${AUTOCONF_VERSION} autoconf && \
+    cd autoconf && mkdir -p /autoconf && ./configure --quiet ${COMMON_ARGS} && make -s -j${JOBS} DESTDIR=/autoconf && \
+    make -s -j${JOBS} DESTDIR=/autoconf install && make -s -j${JOBS} install
 
 ## automake
 FROM stage1 AS automake
@@ -441,9 +439,9 @@ ARG AUTOMAKE_VERSION=1.16.5
 ENV AUTOMAKE_VERSION=${AUTOMAKE_VERSION}
 
 RUN mkdir /sources && cd /sources && wget http://mirror.easyname.at/gnu/automake/automake-${AUTOMAKE_VERSION}.tar.xz && \
-    tar -xvf automake-${AUTOMAKE_VERSION}.tar.xz && mv automake-${AUTOMAKE_VERSION} automake && \
-    cd automake && mkdir -p /automake && ./configure ${COMMON_ARGS} && make DESTDIR=/automake && \
-    make DESTDIR=/automake install && make install
+    tar -xf automake-${AUTOMAKE_VERSION}.tar.xz && mv automake-${AUTOMAKE_VERSION} automake && \
+    cd automake && mkdir -p /automake && ./configure --quiet ${COMMON_ARGS} && make -s -j${JOBS} DESTDIR=/automake && \
+    make -s -j${JOBS} DESTDIR=/automake install && make -s -j${JOBS} install
 
 ## xxhash
 FROM stage1 AS xxhash
@@ -453,10 +451,10 @@ ENV XXHASH_VERSION=${XXHASH_VERSION}
 
 COPY --from=sources-downloader /sources/downloads/xxHash-${XXHASH_VERSION}.tar.gz /sources/
 
-RUN mkdir -p /sources && cd /sources && tar -xvf xxHash-${XXHASH_VERSION}.tar.gz && mv xxHash-${XXHASH_VERSION} xxhash && \
-    tar -xvf xxHash-${XXHASH_VERSION}.tar.gz && mv xxHash-${XXHASH_VERSION} xxhash && \
-    cd xxhash && mkdir -p /xxhash && CC=gcc make DESTDIR=/xxhash && \
-    make DESTDIR=/xxhash install && make install
+RUN mkdir -p /sources && cd /sources && tar -xf xxHash-${XXHASH_VERSION}.tar.gz && mv xxHash-${XXHASH_VERSION} xxhash && \
+    tar -xf xxHash-${XXHASH_VERSION}.tar.gz && mv xxHash-${XXHASH_VERSION} xxhash && \
+    cd xxhash && mkdir -p /xxhash && CC=gcc make -s -j${JOBS} DESTDIR=/xxhash && \
+    make -s -j${JOBS} DESTDIR=/xxhash install && make -s -j${JOBS} install
 
 ## zstd
 FROM xxhash AS zstd
@@ -466,9 +464,9 @@ ENV ZSTD_VERSION=${ZSTD_VERSION}
 
 COPY --from=sources-downloader /sources/downloads/zstd-${ZSTD_VERSION}.tar.gz /sources/
 
-RUN mkdir -p /sources && cd /sources && tar -xvf zstd-${ZSTD_VERSION}.tar.gz && mv zstd-${ZSTD_VERSION} zstd && \
-    cd zstd && mkdir -p /zstd && CC=gcc make DESTDIR=/zstd && \
-    make DESTDIR=/zstd install && make install
+RUN mkdir -p /sources && cd /sources && tar -xf zstd-${ZSTD_VERSION}.tar.gz && mv zstd-${ZSTD_VERSION} zstd && \
+    cd zstd && mkdir -p /zstd && CC=gcc make -s -j${JOBS} DESTDIR=/zstd && \
+    make -s -j${JOBS} DESTDIR=/zstd install && make -s -j${JOBS} install
 
 ## lz4
 FROM zstd AS lz4
@@ -478,9 +476,9 @@ ENV LZ4_VERSION=${LZ4_VERSION}
 
 COPY --from=sources-downloader /sources/downloads/lz4-${LZ4_VERSION}.tar.gz /sources/
 
-RUN mkdir -p /sources && cd /sources && tar -xvf lz4-${LZ4_VERSION}.tar.gz && mv lz4-${LZ4_VERSION} lz4 && \
-    cd lz4 && mkdir -p /lz4 && CC=gcc make PREFIX="/usr" DESTDIR=/lz4 && \
-    make DESTDIR=/lz4 install && make install
+RUN mkdir -p /sources && cd /sources && tar -xf lz4-${LZ4_VERSION}.tar.gz && mv lz4-${LZ4_VERSION} lz4 && \
+    cd lz4 && mkdir -p /lz4 && CC=gcc make -s -j${JOBS} PREFIX="/usr" DESTDIR=/lz4 && \
+    make -s -j${JOBS} DESTDIR=/lz4 install && make -s -j${JOBS} install
 
 ## attr
 FROM lz4 AS attr
@@ -491,14 +489,14 @@ ENV ATTR_VERSION=${ATTR_VERSION}
 COPY --from=sources-downloader /sources/downloads/attr-${ATTR_VERSION}.tar.gz /sources/
 COPY ./patches/attr/basename.patch /sources/
 
-RUN mkdir -p /sources && cd /sources && tar -xvf attr-${ATTR_VERSION}.tar.gz && mv attr-${ATTR_VERSION} attr && \
+RUN mkdir -p /sources && cd /sources && tar -xf attr-${ATTR_VERSION}.tar.gz && mv attr-${ATTR_VERSION} attr && \
     cd attr && mkdir -p /attr && \
     patch -p1 < /sources/basename.patch && \
-    ./configure ${COMMON_ARGS} --disable-dependency-tracking --prefix=/usr --sysconfdir=/etc \
+    ./configure --quiet ${COMMON_ARGS} --disable-dependency-tracking --prefix=/usr --sysconfdir=/etc \
     --mandir=/usr/share/man \
     --localstatedir=/var \
-    --disable-nls && make DESTDIR=/attr && \
-    make DESTDIR=/attr install && make install
+    --disable-nls && make -s -j${JOBS} DESTDIR=/attr && \
+    make -s -j${JOBS} DESTDIR=/attr install && make -s -j${JOBS} install
 
 ## acl
 FROM attr AS acl
@@ -508,10 +506,10 @@ ENV ACL_VERSION=${ACL_VERSION}
 
 COPY --from=sources-downloader /sources/downloads/acl-${ACL_VERSION}.tar.gz /sources/
 
-RUN mkdir -p /sources && cd /sources && tar -xvf acl-${ACL_VERSION}.tar.gz && mv acl-${ACL_VERSION} acl && \
-    tar -xvf acl-${ACL_VERSION}.tar.gz && mv acl-${ACL_VERSION} acl && \
-    cd acl && mkdir -p /acl && ./configure ${COMMON_ARGS} --prefix=/usr --disable-dependency-tracking --libexecdir=/usr/libexec && make DESTDIR=/acl && \
-    make DESTDIR=/acl install && make install
+RUN mkdir -p /sources && cd /sources && tar -xf acl-${ACL_VERSION}.tar.gz && mv acl-${ACL_VERSION} acl && \
+    tar -xf acl-${ACL_VERSION}.tar.gz && mv acl-${ACL_VERSION} acl && \
+    cd acl && mkdir -p /acl && ./configure --quiet ${COMMON_ARGS} --prefix=/usr --disable-dependency-tracking --libexecdir=/usr/libexec && make -s -j${JOBS} DESTDIR=/acl && \
+    make -s -j${JOBS} DESTDIR=/acl install && make -s -j${JOBS} install
 
 ## popt
 FROM acl AS popt
@@ -520,9 +518,9 @@ ARG POPT_VERSION=1.19
 ENV POPT_VERSION=${POPT_VERSION}
 
 RUN mkdir -p /sources && cd /sources && wget http://ftp.rpm.org/popt/releases/popt-1.x/popt-${POPT_VERSION}.tar.gz && \
-    tar -xvf popt-${POPT_VERSION}.tar.gz && mv popt-${POPT_VERSION} popt && \
-    cd popt && mkdir -p /popt && ./configure ${COMMON_ARGS} --disable-dependency-tracking --prefix=/usr && make DESTDIR=/popt && \
-    make DESTDIR=/popt install && make install
+    tar -xf popt-${POPT_VERSION}.tar.gz && mv popt-${POPT_VERSION} popt && \
+    cd popt && mkdir -p /popt && ./configure --quiet ${COMMON_ARGS} --disable-dependency-tracking --prefix=/usr && make -s -j${JOBS} DESTDIR=/popt && \
+    make -s -j${JOBS} DESTDIR=/popt install && make -s -j${JOBS} install
 
 ## zlib
 FROM popt AS zlib
@@ -532,9 +530,9 @@ ENV ZLIB_VERSION=${ZLIB_VERSION}
 
 COPY --from=sources-downloader /sources/downloads/zlib-${ZLIB_VERSION}.tar.gz /sources/
 
-RUN mkdir -p /sources && cd /sources && tar -xvf zlib-${ZLIB_VERSION}.tar.gz && mv zlib-${ZLIB_VERSION} zlib && \
-    cd zlib && mkdir -p /zlib && ./configure --prefix=/usr --shared && make DESTDIR=/zlib && \
-    make DESTDIR=/zlib install && make install
+RUN mkdir -p /sources && cd /sources && tar -xf zlib-${ZLIB_VERSION}.tar.gz && mv zlib-${ZLIB_VERSION} zlib && \
+    cd zlib && mkdir -p /zlib && ./configure --prefix=/usr --shared && make -s -j${JOBS} DESTDIR=/zlib && \
+    make -s -j${JOBS} DESTDIR=/zlib install && make -s -j${JOBS} install
 
 ## gawk
 
@@ -545,13 +543,13 @@ ENV GAWK_VERSION=${GAWK_VERSION}
 
 COPY --from=sources-downloader /sources/downloads/gawk-${GAWK_VERSION}.tar.xz /sources/
 
-RUN mkdir -p /sources && cd /sources && tar -xvf gawk-${GAWK_VERSION}.tar.xz && mv gawk-${GAWK_VERSION} gawk && \
-    cd gawk && mkdir -p /gawk && ./configure ${COMMON_ARGS} --disable-dependency-tracking --prefix=/usr -sysconfdir=/etc \
+RUN mkdir -p /sources && cd /sources && tar -xf gawk-${GAWK_VERSION}.tar.xz && mv gawk-${GAWK_VERSION} gawk && \
+    cd gawk && mkdir -p /gawk && ./configure --quiet ${COMMON_ARGS} --disable-dependency-tracking --prefix=/usr -sysconfdir=/etc \
     --mandir=/usr/share/man \
     --infodir=/usr/share/info \
     --disable-nls \
-    --disable-pma&& make DESTDIR=/gawk && \
-    make DESTDIR=/gawk install && make install
+    --disable-pma&& make -s -j${JOBS} DESTDIR=/gawk && \
+    make -s -j${JOBS} DESTDIR=/gawk install && make -s -j${JOBS} install
 
 ## rsync
 FROM gawk AS rsync
@@ -561,9 +559,9 @@ ENV RSYNC_VERSION=${RSYNC_VERSION}
 
 COPY --from=sources-downloader /sources/downloads/rsync-${RSYNC_VERSION}.tar.gz /sources/
 
-RUN mkdir -p /sources && cd /sources && tar -xvf rsync-${RSYNC_VERSION}.tar.gz && mv rsync-${RSYNC_VERSION} rsync && \
+RUN mkdir -p /sources && cd /sources && tar -xf rsync-${RSYNC_VERSION}.tar.gz && mv rsync-${RSYNC_VERSION} rsync && \
     cd rsync && mkdir -p /rsync && \
-    ./configure ${COMMON_ARGS} --prefix=/usr \
+    ./configure --quiet ${COMMON_ARGS} --prefix=/usr \
     --sysconfdir=/etc \
     --mandir=/usr/share/man \
     --localstatedir=/var \
@@ -575,8 +573,8 @@ RUN mkdir -p /sources && cd /sources && tar -xvf rsync-${RSYNC_VERSION}.tar.gz &
     --without-included-popt \
     --without-included-zlib \
     --disable-md2man \
-    --disable-openssl && make DESTDIR=/rsync && \
-    make DESTDIR=/rsync install && make install
+    --disable-openssl && make -s -j${JOBS} DESTDIR=/rsync && \
+    make -s -j${JOBS} DESTDIR=/rsync install && make -s -j${JOBS} install
 
 ## binutils
 FROM stage1 AS binutils
@@ -585,9 +583,9 @@ ARG BINUTILS_VERSION=2.44
 ENV BINUTILS_VERSION=${BINUTILS_VERSION}
 
 RUN mkdir /sources && cd /sources && wget https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.xz && \
-    tar -xvf binutils-${BINUTILS_VERSION}.tar.xz && mv binutils-${BINUTILS_VERSION} binutils && \
-    cd binutils && mkdir -p /binutils && ./configure ${COMMON_ARGS} && make DESTDIR=/binutils && \
-    make DESTDIR=/binutils install && make install
+    tar -xf binutils-${BINUTILS_VERSION}.tar.xz && mv binutils-${BINUTILS_VERSION} binutils && \
+    cd binutils && mkdir -p /binutils && ./configure --quiet ${COMMON_ARGS} && make -s -j${JOBS} DESTDIR=/binutils && \
+    make -s -j${JOBS} DESTDIR=/binutils install && make -s -j${JOBS} install
 
 ## ncurses
 FROM stage1 AS ncurses
@@ -596,10 +594,10 @@ ARG NCURSES_VERSION=6.5
 ENV NCURSES_VERSION=${NCURSES_VERSION}
 
 RUN mkdir /sources && cd /sources && wget http://ftp.gnu.org/gnu/ncurses/ncurses-${NCURSES_VERSION}.tar.gz && \
-    tar -xvf ncurses-${NCURSES_VERSION}.tar.gz && mv ncurses-${NCURSES_VERSION} ncurses && \
+    tar -xf ncurses-${NCURSES_VERSION}.tar.gz && mv ncurses-${NCURSES_VERSION} ncurses && \
     cd ncurses && mkdir -p /ncurses && sed -i s/mawk// configure && mkdir build && \
-    cd build && ../configure ${COMMON_ARGS} && make -C include &&  make -C progs tic && cd .. && \
-    ./configure ${COMMON_ARGS} \
+    cd build && ../configure --quiet ${COMMON_ARGS} && make -s -C include &&  make -s -C progs tic && cd .. && \
+    ./configure --quiet ${COMMON_ARGS} \
     --mandir=/usr/share/man \
     --with-manpage-format=normal \
     --with-shared \
@@ -608,8 +606,8 @@ RUN mkdir /sources && cd /sources && wget http://ftp.gnu.org/gnu/ncurses/ncurses
     --without-normal \
     --disable-stripping \
     --enable-widec && \
-    make -j${JOBS} && \
-    make DESTDIR=/ncurses TIC_PATH=/sources/ncurses/build/progs/tic install && make install && echo "INPUT(-lncursesw)" > /ncurses/usr/lib/libncurses.so && \
+    make -s -j${JOBS} && \
+    make -s DESTDIR=/ncurses TIC_PATH=/sources/ncurses/build/progs/tic install && make -s -j${JOBS} install && echo "INPUT(-lncursesw)" > /ncurses/usr/lib/libncurses.so && \
     cp /ncurses/usr/lib/libncurses.so /usr/lib/libncurses.so
 
 ## m4 (from stage1, ready to be used in the final image)
@@ -619,9 +617,9 @@ ARG M4_VERSION=1.4.20
 ENV M4_VERSION=${M4_VERSION}
 
 RUN mkdir /sources && cd /sources && wget http://mirror.easyname.at/gnu/m4/m4-${M4_VERSION}.tar.xz && \
-    tar -xvf m4-${M4_VERSION}.tar.xz && mv m4-${M4_VERSION} m4 && \
-    cd m4 && mkdir -p /m4 && ./configure ${COMMON_ARGS} --disable-dependency-tracking && make DESTDIR=/m4 && \
-    make DESTDIR=/m4 install && make install
+    tar -xf m4-${M4_VERSION}.tar.xz && mv m4-${M4_VERSION} m4 && \
+    cd m4 && mkdir -p /m4 && ./configure --quiet ${COMMON_ARGS} --disable-dependency-tracking && make -s -j${JOBS} DESTDIR=/m4 && \
+    make -s -j${JOBS} DESTDIR=/m4 install && make -s -j${JOBS} install
 
 ## readline
 FROM stage1 AS readline
@@ -630,9 +628,9 @@ ARG READLINE_VERSION=8.3
 ENV READLINE_VERSION=${READLINE_VERSION}
 
 RUN mkdir -p /sources && cd /sources && wget http://mirror.easyname.at/gnu/readline/readline-${READLINE_VERSION}.tar.gz && \
-    tar -xvf readline-${READLINE_VERSION}.tar.gz && mv readline-${READLINE_VERSION} readline && \
-    cd readline && mkdir -p /readline && ./configure ${COMMON_ARGS} --disable-dependency-tracking && make DESTDIR=/readline && \
-    make DESTDIR=/readline install && make install
+    tar -xf readline-${READLINE_VERSION}.tar.gz && mv readline-${READLINE_VERSION} readline && \
+    cd readline && mkdir -p /readline && ./configure --quiet ${COMMON_ARGS} --disable-dependency-tracking && make -s -j${JOBS} DESTDIR=/readline && \
+    make -s -j${JOBS} DESTDIR=/readline install && make -s -j${JOBS} install
 
 ## bash
 FROM readline AS bash
@@ -643,8 +641,8 @@ ENV BASH_VERSION=${BASH_VERSION}
 COPY ./files/bash/bashrc /sources/bashrc
 COPY ./files/bash/profile-bashrc.sh /sources/profile-bashrc.sh
 RUN mkdir -p /sources && cd /sources && wget http://mirror.easyname.at/gnu/bash/bash-${BASH_VERSION}.tar.gz && \
-    tar -xvf bash-${BASH_VERSION}.tar.gz && mv bash-${BASH_VERSION} bash && \
-    cd bash && mkdir -p /bash && ./configure ${COMMON_ARGS} \
+    tar -xf bash-${BASH_VERSION}.tar.gz && mv bash-${BASH_VERSION} bash && \
+    cd bash && mkdir -p /bash && ./configure --quiet ${COMMON_ARGS} \
     --build=${BUILD} \
     --host=${TARGET} \
     --prefix=/usr \
@@ -655,11 +653,23 @@ RUN mkdir -p /sources && cd /sources && wget http://mirror.easyname.at/gnu/bash/
     --disable-nls \
     --enable-readline \
     --without-bash-malloc \
-    --with-installed-readline && make y.tab.c && make builtins/libbuiltins.a && make && \
+    --with-installed-readline && make -s -j${JOBS} y.tab.c && make -s -j${JOBS} builtins/libbuiltins.a && make -s -j${JOBS} && \
     mkdir -p /bash/etc/bash && \
     install -Dm644  /sources/bashrc /bash/etc/bash/bashrc && \
     install -Dm644  /sources/profile-bashrc.sh /bash/etc/profile.d/00-bashrc.sh && \
-    make DESTDIR=/bash install && make install # && rm -rf /bash/usr/share/locale
+    make -s -j${JOBS} DESTDIR=/bash install && make -s -j${JOBS} install # && rm -rf /bash/usr/share/locale
+
+## libcap
+FROM bash AS libcap
+
+ARG LIBCAP_VERSION=2.76
+ENV LIBCAP_VERSION=${LIBCAP_VERSION}
+
+COPY --from=sources-downloader /sources/downloads/libcap-${LIBCAP_VERSION}.tar.xz /sources/
+
+RUN mkdir -p /sources && cd /sources && tar -xf libcap-${LIBCAP_VERSION}.tar.xz && mv libcap-${LIBCAP_VERSION} libcap && \
+    cd libcap && mkdir -p /libcap && make -s -j${JOBS} BUILD_CC=gcc CC="${CC:-gcc}" && \
+    make -s -j${JOBS} DESTDIR=/libcap PAM_LIBDIR=/lib prefix=/usr SBINDIR=/sbin lib=lib RAISE_SETFCAP=no GOLANG=no install && make -s -j${JOBS} GOLANG=no PAM_LIBDIR=/lib lib=lib prefix=/usr SBINDIR=/sbin RAISE_SETFCAP=no install
 
 ## perl
 FROM m4 AS perl
@@ -673,9 +683,9 @@ ENV PERL_CROSS=1.6.2
 
 RUN cd /sources && \
     wget http://www.cpan.org/src/5.0/perl-${PERL_VERSION}.tar.xz && \
-    tar -xvf perl-${PERL_VERSION}.tar.xz && mv perl-${PERL_VERSION} perl && \
+    tar -xf perl-${PERL_VERSION}.tar.xz && mv perl-${PERL_VERSION} perl && \
     cd perl && \
-       ln -s /usr/bin/gcc /usr/bin/cc && ./Configure -des -Dprefix=/usr 	-Dcccdlflags='-fPIC' \
+       ln -s /usr/bin/gcc /usr/bin/cc && ./Configure -s -des -Dprefix=/usr -Dcccdlflags='-fPIC' \
        -Dccdlflags='-rdynamic' \
        -Dprivlib=/usr/share/perl5/core_perl \
        -Darchlib=/usr/lib/perl5/core_perl \
@@ -703,8 +713,8 @@ RUN cd /sources && \
        -Ud_fpos64_t \
        -Ud_off64_t \
        -Dusenm \
-       -Duse64bitint && make libperl.so && \
-        make DESTDIR=/perl -j 8 && make DESTDIR=/perl install && make install
+       -Duse64bitint && make -s -j${JOBS} libperl.so && \
+        make -s -j${JOBS} DESTDIR=/perl && make -s -j${JOBS} DESTDIR=/perl install && make -s -j${JOBS} install
 
 ## openssl
 FROM rsync AS openssl
@@ -720,14 +730,13 @@ RUN rsync -aHAX --keep-dirlinks  /zlib/. /
 
 COPY --from=sources-downloader /sources/downloads/openssl-${OPENSSL_VERSION}.tar.gz /sources/
 
-RUN cd /sources && tar -xvf openssl-${OPENSSL_VERSION}.tar.gz && mv openssl-${OPENSSL_VERSION} openssl && \
-    cd openssl && mkdir -p /openssl && ./config --prefix=/usr         \
+RUN cd /sources && tar -xf openssl-${OPENSSL_VERSION}.tar.gz && mv openssl-${OPENSSL_VERSION} openssl && \
+    cd openssl && mkdir -p /openssl && ./Configure --prefix=/usr         \
     --openssldir=/etc/ssl \
     --libdir=lib          \
-    shared                \
-    zlib-dynamic 2>&1 && \
-    make DESTDIR=/openssl 2>&1  && \
-    make DESTDIR=/openssl install && make install
+    shared zlib-dynamic 2>&1 && \
+    make -s -j${JOBS} DESTDIR=/openssl 2>&1  && \
+    make -s -j${JOBS} DESTDIR=/openssl install_sw install_ssldirs && make -s -j${JOBS} install_sw install_ssldirs
 
 ## Busybox (from stage1, ready to be used in the final image)
 FROM openssl AS busybox
@@ -737,10 +746,10 @@ COPY --from=busybox-stage0 /sources /sources
 ARG BUSYBOX_VERSION=1.37.0
 ENV BUSYBOX_VERSION=${BUSYBOX_VERSION}
 
-RUN cd /sources && rm -rfv busybox-${BUSYBOX_VERSION} && tar -xvf busybox-${BUSYBOX_VERSION}.tar.bz2 && \
+RUN cd /sources && rm -rfv busybox-${BUSYBOX_VERSION} && tar -xf busybox-${BUSYBOX_VERSION}.tar.bz2 && \
     cd busybox-${BUSYBOX_VERSION} && \
-    make -j1 distclean && \
-    make defconfig && \
+    make -s distclean && \
+    make -s defconfig && \
     sed -i 's/\(CONFIG_\)\(.*\)\(INETD\)\(.*\)=y/# \1\2\3\4 is not set/g' .config && \
     sed -i 's/\(CONFIG_IFPLUGD\)=y/# \1 is not set/' .config && \
     sed -i 's/\(CONFIG_FEATURE_WTMP\)=y/# \1 is not set/' .config && \
@@ -749,8 +758,8 @@ RUN cd /sources && rm -rfv busybox-${BUSYBOX_VERSION} && tar -xvf busybox-${BUSY
     sed -i 's/\(CONFIG_TCPSVD\)=y/# \1 is not set/' .config && \
     sed -i 's/\(CONFIG_TC\)=y/# \1 is not set/' .config
 RUN cd /sources/busybox-${BUSYBOX_VERSION} && \
-    make -j1 && \
-    make CONFIG_PREFIX="/sysroot" install && make install
+    make -s && \
+    make -s CONFIG_PREFIX="/sysroot" install && make -s -j${JOBS} install
 
 ## coreutils
 FROM rsync AS coreutils
@@ -761,9 +770,15 @@ ENV COREUTILS_VERSION=${COREUTILS_VERSION}
 COPY --from=openssl /openssl /openssl
 RUN rsync -aHAX --keep-dirlinks  /openssl/. /
 
+COPY --from=libcap /libcap /libcap
+RUN rsync -aHAX --keep-dirlinks  /libcap/. /
+
+COPY --from=perl /perl /perl
+RUN rsync -aHAX --keep-dirlinks  /perl/. /
+
 RUN mkdir -p /sources && cd /sources && wget http://mirror.easyname.at/gnu/coreutils/coreutils-${COREUTILS_VERSION}.tar.xz && \
-    tar -xvf coreutils-${COREUTILS_VERSION}.tar.xz && mv coreutils-${COREUTILS_VERSION} coreutils && \
-    cd coreutils && mkdir -p /coreutils && ./configure ${COMMON_ARGS} \
+    tar -xf coreutils-${COREUTILS_VERSION}.tar.xz && mv coreutils-${COREUTILS_VERSION} coreutils && \
+    cd coreutils && mkdir -p /coreutils && ./configure --quiet ${COMMON_ARGS} \
     --prefix=/usr \
     --bindir=/bin \
     --sysconfdir=/etc \
@@ -774,8 +789,8 @@ RUN mkdir -p /sources && cd /sources && wget http://mirror.easyname.at/gnu/coreu
     --enable-single-binary=symlinks \
     --enable-single-binary-exceptions=env,fmt,sha512sum \
     --with-openssl \
-    --disable-dependency-tracking && make DESTDIR=/coreutils && \
-    make DESTDIR=/coreutils install
+    --disable-dependency-tracking && make -s -j${JOBS} DESTDIR=/coreutils && \
+    make -s -j${JOBS} DESTDIR=/coreutils install
 
 ## findutils
 FROM stage1 AS findutils
@@ -784,9 +799,9 @@ ARG FINDUTILS_VERSION=4.10.0
 ENV FINDUTILS_VERSION=${FINDUTILS_VERSION}
 
 RUN mkdir -p /sources && cd /sources && wget http://mirror.easyname.at/gnu/findutils/findutils-${FINDUTILS_VERSION}.tar.xz && \
-    tar -xvf findutils-${FINDUTILS_VERSION}.tar.xz && mv findutils-${FINDUTILS_VERSION} findutils && \
-    cd findutils && mkdir -p /findutils && ./configure ${COMMON_ARGS} --disable-dependency-tracking && make DESTDIR=/findutils && \
-    make DESTDIR=/findutils install && make install
+    tar -xf findutils-${FINDUTILS_VERSION}.tar.xz && mv findutils-${FINDUTILS_VERSION} findutils && \
+    cd findutils && mkdir -p /findutils && ./configure --quiet ${COMMON_ARGS} --disable-dependency-tracking && make -s -j${JOBS} DESTDIR=/findutils && \
+    make -s -j${JOBS} DESTDIR=/findutils install && make -s -j${JOBS} install
 
 ## grep
 FROM stage1 AS grep
@@ -795,9 +810,9 @@ ARG GREP_VERSION=3.12
 ENV GREP_VERSION=${GREP_VERSION}
 
 RUN mkdir -p /sources && cd /sources && wget http://mirror.easyname.at/gnu/grep/grep-${GREP_VERSION}.tar.xz && \
-    tar -xvf grep-${GREP_VERSION}.tar.xz && mv grep-${GREP_VERSION} grep && \
-    cd grep && mkdir -p /grep && ./configure ${COMMON_ARGS} --disable-dependency-tracking && make DESTDIR=/grep && \
-    make DESTDIR=/grep install && make install
+    tar -xf grep-${GREP_VERSION}.tar.xz && mv grep-${GREP_VERSION} grep && \
+    cd grep && mkdir -p /grep && ./configure --quiet ${COMMON_ARGS} --disable-dependency-tracking && make -s -j${JOBS} DESTDIR=/grep && \
+    make -s -j${JOBS} DESTDIR=/grep install && make -s -j${JOBS} install
 
 ## ca-certificates
 FROM rsync AS ca-certificates
@@ -832,9 +847,9 @@ RUN rsync -aHAX --keep-dirlinks  /findutils/. /
 
 COPY --from=sources-downloader /sources/downloads/ca-certificates-${CA_CERTIFICATES_VERSION}.tar.bz2 /sources/
 
-RUN mkdir -p /sources && cd /sources && tar -xvf ca-certificates-${CA_CERTIFICATES_VERSION}.tar.bz2 && mv ca-certificates-${CA_CERTIFICATES_VERSION} ca-certificates && \
-    cd ca-certificates && mkdir -p /ca-certificates && CC=gcc make && \
-    make DESTDIR=/ca-certificates install
+RUN mkdir -p /sources && cd /sources && tar -xf ca-certificates-${CA_CERTIFICATES_VERSION}.tar.bz2 && mv ca-certificates-${CA_CERTIFICATES_VERSION} ca-certificates && \
+    cd ca-certificates && mkdir -p /ca-certificates && CC=gcc make -s -j${JOBS} && \
+    make -s -j${JOBS} DESTDIR=/ca-certificates install
 
 COPY ./files/ca-certificates/post_install.sh /sources/post_install.sh
 RUN bash /sources/post_install.sh
@@ -849,9 +864,9 @@ ENV CFLAGS="${CFLAGS//-Os/-O2} -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_
 
 COPY --from=sources-downloader /sources/downloads/sqlite-autoconf-${SQLITE3_VERSION}.tar.gz /sources/
 
-RUN mkdir -p /sources && cd /sources && tar -xvf sqlite-autoconf-${SQLITE3_VERSION}.tar.gz && \
+RUN mkdir -p /sources && cd /sources && tar -xf sqlite-autoconf-${SQLITE3_VERSION}.tar.gz && \
     mv sqlite-autoconf-${SQLITE3_VERSION} sqlite3 && \
-    cd sqlite3 && mkdir -p /sqlite3 && ./configure \
+    cd sqlite3 && mkdir -p /sqlite3 && ./configure --quiet \
 		--prefix=/usr \
 		--enable-threadsafe \
 		--enable-session \
@@ -860,8 +875,8 @@ RUN mkdir -p /sources && cd /sources && tar -xvf sqlite-autoconf-${SQLITE3_VERSI
 		--enable-fts4 \
 		--enable-fts5 \
 		--soname=legacy && \
-    make && \
-    make DESTDIR=/sqlite3 install && make install
+    make -s -j${JOBS} && \
+    make -s -j${JOBS} DESTDIR=/sqlite3 install && make -s -j${JOBS} install
 
 ## curl
 FROM rsync AS curl
@@ -880,11 +895,10 @@ ENV CURL_VERSION=${CURL_VERSION}
 
 COPY --from=sources-downloader /sources/downloads/curl-${CURL_VERSION}.tar.gz /sources/
 
-RUN mkdir -p /sources && cd /sources && tar -xvf curl-${CURL_VERSION}.tar.gz && mv curl-${CURL_VERSION} curl && \
-    cd curl && mkdir -p /curl && ./configure  ${COMMON_ARGS} --disable-dependency-tracking --enable-ipv6 \
+RUN mkdir -p /sources && cd /sources && tar -xf curl-${CURL_VERSION}.tar.gz && mv curl-${CURL_VERSION} curl && \
+    cd curl && mkdir -p /curl && ./configure --quiet ${COMMON_ARGS} --disable-dependency-tracking --enable-ipv6 \
     --enable-unix-sockets \
     --enable-static \
-    --without-libidn \
     --without-libidn2 \
     --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt \
     --with-ca-path=/etc/ssl/certs \
@@ -898,12 +912,12 @@ RUN mkdir -p /sources && cd /sources && tar -xvf curl-${CURL_VERSION}.tar.gz && 
     --with-nghttp2 \
     --disable-ldap \
     --with-pic \
-    --without-libssh2 && make DESTDIR=/curl && \
-    make DESTDIR=/curl install && make install
+    --without-libssh2 && make -s -j${JOBS} DESTDIR=/curl && \
+    make -s -j${JOBS} DESTDIR=/curl install && make -s -j${JOBS} install
 
 ## python
 FROM rsync AS python-build
-
+ARG JOBS
 ARG PYTHON_VERSION=3.12.11
 ENV PYTHON_VERSION=${PYTHON_VERSION}
 
@@ -919,21 +933,27 @@ RUN rsync -aHAX --keep-dirlinks  /zlib/. /
 COPY --from=readline /readline /readline
 RUN rsync -aHAX --keep-dirlinks  /readline/. /
 
+COPY --from=pkgconfig /pkgconfig /pkgconfig
+RUN rsync -aHAX --keep-dirlinks  /pkgconfig/. /
+
 COPY --from=sources-downloader /sources/downloads/Python-${PYTHON_VERSION}.tar.xz /sources/
 
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh && mkdir -p /sources && cd /sources && tar -xvf Python-${PYTHON_VERSION}.tar.xz && mv Python-${PYTHON_VERSION} python && \
-    cd python && mkdir -p /python && ./configure --disable-dependency-tracking --prefix=/usr \
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh && mkdir -p /sources && cd /sources && tar -xf Python-${PYTHON_VERSION}.tar.xz && mv Python-${PYTHON_VERSION} python && \
+    cd python && mkdir -p /python
+WORKDIR /sources/python
+RUN ./configure --quiet --prefix=/usr \
     --enable-ipv6 \
     --enable-loadable-sqlite-extensions \
-    --enable-optimizations \
     --enable-shared \
     --with-ensurepip=install \
-    --with-lto \
     --with-computed-gotos \
-    --with-dbmliborder=gdbm:ndbm  2>&1 && make DESTDIR=/python  2>&1 && \
-    make DESTDIR=/python install  2>&1 && make install 2>&1
-    #--with-system-libmpdec \
-    #--with-system-expat \
+    --disable-test-modules \
+    --with-dbmliborder=gdbm:ndbm
+RUN make -s -j${JOBS} DESTDIR=/python
+RUN make -s -j${JOBS} DESTDIR=/python install
+RUN make -s -j${JOBS} install 2>&1
+
+
 
 ## util-linux
 FROM bash AS util-linux
@@ -945,7 +965,7 @@ COPY --from=sources-downloader /sources/downloads/util-linux-${UTIL_LINUX_VERSIO
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh && mkdir -p /sources && cd /sources && tar -xf util-linux-${UTIL_LINUX_VERSION}.tar.xz && \
     mv util-linux-${UTIL_LINUX_VERSION} util-linux && \
-    cd util-linux && mkdir -p /util-linux && ./configure ${COMMON_ARGS} --disable-dependency-tracking  --prefix=/usr \
+    cd util-linux && mkdir -p /util-linux && ./configure --quiet ${COMMON_ARGS} --disable-dependency-tracking  --prefix=/usr \
     --libdir=/usr/lib \
     --disable-silent-rules \
     --enable-newgrp \
@@ -956,20 +976,9 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh && mkdir -p /sources && cd /sources &&
     --disable-chfn-chsh \
     --with-vendordir=/usr/lib \
     --enable-fs-paths-extra=/usr/sbin \
-    && make DESTDIR=/util-linux && \
-    make DESTDIR=/util-linux install && make install
+    && make -s -j${JOBS} DESTDIR=/util-linux && \
+    make -s -j${JOBS} DESTDIR=/util-linux install && make -s -j${JOBS} install
 
-## libcap
-FROM bash AS libcap
-
-ARG LIBCAP_VERSION=2.76
-ENV LIBCAP_VERSION=${LIBCAP_VERSION}
-
-COPY --from=sources-downloader /sources/downloads/libcap-${LIBCAP_VERSION}.tar.xz /sources/
-
-RUN mkdir -p /sources && cd /sources && tar -xvf libcap-${LIBCAP_VERSION}.tar.xz && mv libcap-${LIBCAP_VERSION} libcap && \
-    cd libcap && mkdir -p /libcap && make BUILD_CC=gcc CC="${CC:-gcc}" && \
-    make DESTDIR=/libcap PAM_LIBDIR=/lib prefix=/usr SBINDIR=/sbin lib=lib RAISE_SETFCAP=no GOLANG=no install && make GOLANG=no PAM_LIBDIR=/lib lib=lib prefix=/usr SBINDIR=/sbin RAISE_SETFCAP=no install
 
 ## gperf
 FROM stage1 AS gperf
@@ -978,10 +987,10 @@ ARG GPERF_VERSION=3.3
 ENV GPERF_VERSION=${GPERF_VERSION}
 
 RUN mkdir -p /sources && cd /sources && wget http://mirror.easyname.at/gnu/gperf/gperf-${GPERF_VERSION}.tar.gz && \
-    tar -xvf gperf-${GPERF_VERSION}.tar.gz && mv gperf-${GPERF_VERSION} gperf && \
-    cd gperf && mkdir -p /gperf && ./configure ${COMMON_ARGS} --disable-dependency-tracking --prefix=/usr && \
-    make BUILD_CC=gcc CC="${CC:-gcc}" lib=lib prefix=/usr GOLANG=no DESTDIR=/gperf && \
-    make DESTDIR=/gperf install && make install
+    tar -xf gperf-${GPERF_VERSION}.tar.gz && mv gperf-${GPERF_VERSION} gperf && \
+    cd gperf && mkdir -p /gperf && ./configure --quiet ${COMMON_ARGS} --disable-dependency-tracking --prefix=/usr && \
+    make -s -j${JOBS} BUILD_CC=gcc CC="${CC:-gcc}" lib=lib prefix=/usr GOLANG=no DESTDIR=/gperf && \
+    make -s -j${JOBS} DESTDIR=/gperf install && make -s -j${JOBS} install
 
 ## libseccomp
 FROM rsync AS libseccomp
@@ -990,10 +999,10 @@ RUN rsync -aHAX --keep-dirlinks  /gperf/. /
 COPY --from=sources-downloader /sources/downloads/libseccomp.tar.gz /sources/
 RUN mkdir -p /libseccomp
 WORKDIR /sources
-RUN tar -xvf libseccomp.tar.gz && mv libseccomp-* libseccomp
+RUN tar -xf libseccomp.tar.gz && mv libseccomp-* libseccomp
 WORKDIR /sources/libseccomp
-RUN ./configure --prefix=/usr --disable-static
-RUN make && make install DESTDIR=/libseccomp
+RUN ./configure --quiet --prefix=/usr --disable-static
+RUN make -s -j${JOBS} && make -s -j${JOBS} install DESTDIR=/libseccomp
 
 
 ## expat
@@ -1003,10 +1012,10 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 COPY --from=sources-downloader /sources/downloads/expat.tar.gz /sources/
 RUN mkdir -p /expat
 WORKDIR /sources
-RUN tar -xvf expat.tar.gz && mv expat-* expat
+RUN tar -xf expat.tar.gz && mv expat-* expat
 WORKDIR /sources/expat
-RUN bash ./configure --prefix=/usr --disable-static
-RUN make && make install DESTDIR=/expat
+RUN bash ./configure --quiet --prefix=/usr --disable-static
+RUN make -s -j${JOBS} && make -s -j${JOBS} install DESTDIR=/expat
 
 
 ## dbus first pass without systemd support so we can build systemd afterwards
@@ -1023,7 +1032,7 @@ COPY --from=sources-downloader /sources/downloads/dbus.tar.xz /sources/
 RUN mkdir -p /dbus
 WORKDIR /sources
 RUN pip3 install meson ninja
-RUN tar -xvf dbus.tar.xz && mv dbus-* dbus
+RUN tar -xf dbus.tar.xz && mv dbus-* dbus
 WORKDIR /sources/dbus
 RUN meson setup buildDir --prefix=/usr --buildtype=release
 RUN DESTDIR=/dbus ninja -C buildDir install
@@ -1071,9 +1080,12 @@ RUN rsync -aHAX --keep-dirlinks  /libseccomp/. /
 COPY --from=dbus /dbus /dbus
 RUN rsync -aHAX --keep-dirlinks  /dbus/. /
 
-COPY --from=sources-downloader /sources/downloads/systemd /sources/downloads/systemd
+COPY --from=sources-downloader /sources/downloads/systemd /sources/systemd
 ENV CFLAGS="-D __UAPI_DEF_ETHHDR=0 -D _LARGEFILE64_SOURCE"
-RUN rm -fv /bin/sh && ln -s /bin/bash /bin/sh && mkdir -p /sources && cd /sources/downloads/systemd && mkdir -p /systemd && python3 -m pip install meson ninja jinja2 && mkdir -p build && cd build && /usr/bin/meson setup .. \
+RUN mkdir -p /systemd
+RUN python3 -m pip install meson ninja jinja2
+WORKDIR /sources/systemd
+RUN /usr/bin/meson setup buildDir \
       --prefix=/usr           \
       --buildtype=release     \
       -D dbus=true \
@@ -1100,8 +1112,10 @@ RUN rm -fv /bin/sh && ln -s /bin/bash /bin/sh && mkdir -p /sources && cd /source
       -D nobody-group=nogroup \
       -D sysupdate=disabled   \
       -D ukify=disabled       \
-      -D docdir=/usr/share/doc/systemd-${SYSTEMD_VERSION} 2>&1 && ninja 2>&1 && \
-     DESTDIR=/systemd ninja install && ninja install
+      -D docdir=/usr/share/doc/systemd-${SYSTEMD_VERSION}
+RUN ninja -C buildDir
+RUN DESTDIR=/systemd ninja -C buildDir install
+RUN ninja -C buildDir install
 
 
 ## dbus second pass pass with systemd support, so we can have a working systemd and dbus
@@ -1120,7 +1134,7 @@ COPY --from=sources-downloader /sources/downloads/dbus.tar.xz /sources/
 RUN mkdir -p /dbus
 WORKDIR /sources
 RUN pip3 install meson ninja
-RUN tar -xvf dbus.tar.xz && mv dbus-* dbus
+RUN tar -xf dbus.tar.xz && mv dbus-* dbus
 WORKDIR /sources/dbus
 RUN meson setup buildDir --prefix=/usr --buildtype=release
 RUN DESTDIR=/dbus ninja -C buildDir install
@@ -1137,14 +1151,16 @@ RUN rsync -aHAX --keep-dirlinks  /coreutils/. /
 # Use openssl for libssl and libcrypto
 COPY --from=openssl /openssl /openssl
 RUN rsync -aHAX --keep-dirlinks  /openssl/. /
+COPY --from=libcap /libcap /libcap
+RUN rsync -aHAX --keep-dirlinks  /libcap/. /
 
 COPY --from=sources-downloader /sources/downloads/kbd.tar.gz /sources/
 RUN mkdir -p /kbd
 WORKDIR /sources
-RUN tar -xvf kbd.tar.gz && mv kbd-* kbd
+RUN tar -xf kbd.tar.gz && mv kbd-* kbd
 WORKDIR /sources/kbd
-RUN ./configure --prefix=/usr --disable-tests --disable-vlock -enable-libkeymap --enable-libkfont
-RUN make && make install DESTDIR=/kbd
+RUN ./configure --quiet --prefix=/usr --disable-tests --disable-vlock -enable-libkeymap --enable-libkfont
+RUN make -s -j${JOBS} && make -s -j${JOBS} install DESTDIR=/kbd
 
 ## strace
 FROM rsync AS strace
@@ -1154,10 +1170,10 @@ RUN rsync -aHAX --keep-dirlinks  /gawk/. /
 COPY --from=sources-downloader /sources/downloads/strace.tar.xz /sources/
 RUN mkdir -p /strace
 WORKDIR /sources
-RUN tar -xvf strace.tar.xz && mv strace-* strace
+RUN tar -xf strace.tar.xz && mv strace-* strace
 WORKDIR /sources/strace
-RUN ./configure --prefix=/usr --disable-static --enable-mpers=check
-RUN make && make install DESTDIR=/strace
+RUN ./configure --quiet --prefix=/usr --disable-static --enable-mpers=check
+RUN make -s -j${JOBS} && make -s -j${JOBS} install DESTDIR=/strace
 
 ## libmnl
 FROM rsync AS libmnl
@@ -1166,8 +1182,8 @@ RUN mkdir -p /libmnl
 WORKDIR /sources
 RUN tar -xf libmnl.tar.bz2 && mv libmnl-* libmnl
 WORKDIR /sources/libmnl
-RUN ./configure --prefix=/usr
-RUN make && make install DESTDIR=/libmnl
+RUN ./configure --quiet --prefix=/usr
+RUN make -s -j${JOBS} && make -s -j${JOBS} install DESTDIR=/libmnl
 
 ## libnftnl
 FROM rsync AS libnftnl
@@ -1181,8 +1197,8 @@ RUN mkdir -p /libnftnl
 WORKDIR /sources
 RUN tar -xf libnftnl.tar.xz && mv libnftnl-* libnftnl
 WORKDIR /sources/libnftnl
-RUN ./configure --prefix=/usr
-RUN make && make install DESTDIR=/libnftnl
+RUN ./configure --quiet --prefix=/usr
+RUN make -s -j${JOBS} && make -s -j${JOBS} install DESTDIR=/libnftnl
 
 ## iptables
 FROM rsync AS iptables
@@ -1204,8 +1220,8 @@ WORKDIR /sources/iptables
 # otherwise its redeclared in other headers and fails the build
 RUN sed -i '/^[[:space:]]*#include[[:space:]]*<linux\/if_ether\.h>/d' extensions/*.c
 
-RUN ./configure --prefix=/usr --with-xtlibdir=/usr/lib/xtables
-RUN make && make install DESTDIR=/iptables
+RUN ./configure --quiet --prefix=/usr --with-xtlibdir=/usr/lib/xtables
+RUN make -s -s && make -s -s install DESTDIR=/iptables
 
 ########################################################
 #
@@ -1332,7 +1348,7 @@ RUN luet install -y kernels/linux-tiny --system-target /kernel
 ## Immucore for initramfs
 FROM alpine AS immucore
 RUN wget https://github.com/kairos-io/immucore/releases/download/v0.11.3/immucore-v0.11.3-linux-amd64.tar.gz
-RUN tar xvf immucore-v0.11.3-linux-amd64.tar.gz
+RUN tar xf immucore-v0.11.3-linux-amd64.tar.gz
 RUN mv immucore /immucore
 RUN chmod +x /immucore
 RUN apk add --no-cache upx
@@ -1341,7 +1357,7 @@ RUN upx /immucore
 # Agent
 FROM alpine AS kairos-agent
 RUN wget https://github.com/kairos-io/kairos-agent/releases/download/v2.25.0/kairos-agent-v2.25.0-linux-amd64.tar.gz
-RUN tar xvf kairos-agent-v2.25.0-linux-amd64.tar.gz
+RUN tar xf kairos-agent-v2.25.0-linux-amd64.tar.gz
 RUN mv kairos-agent /kairos-agent
 RUN chmod +x /kairos-agent
 RUN apk add --no-cache upx

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MUSL_CROSS_MAKE_VERSION=6f3701d08137496d5aac479e3a3977b5ae993c1f
 IMAGE_NAME=ukairos
 AURORA_IMAGE=quay.io/kairos/auroraboot:v0.9.0
-TARGET=default
+TARGET ?= default
 
 .PHONY: build
 build:


### PR DESCRIPTION
- Replace `tar -xvf` with `tar -xf` for silent extraction.
- Use `make -s` to suppress output during build processes.
- Ensure consistent use of quiet mode in configuration commands.
- These changes enhance build performance and reduce log clutter.
Also make the python build a normal one. The optimized is ok but its too time consuming to keep building it now and should be done only on releases. The normal one should be good enough for now, which should reduce the time it takes to build.