### PR TITLE
chore: update KAIROS_INIT version to v0.6.1

### DIFF
--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=hadron
-ARG KAIROS_INIT=main
+ARG KAIROS_INIT=v0.6.1
 
 FROM quay.io/kairos/kairos-init:${KAIROS_INIT} AS kairos-init
 


### PR DESCRIPTION
- Changed `KAIROS_INIT` from `main` to `v0.6.1` to use the latest stable release.