### PR TITLE
fix: make a semver version to make auroraboot happy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ INIT_IMAGE_NAME ?= hadron-init
 AURORA_IMAGE ?= quay.io/kairos/auroraboot:v0.9.0
 TARGET ?= default
 JOBS ?= 24
-GIT_VERSION := $(shell git describe --tags --always --dirty)
+GIT_VERSION := v0.0.0-$(shell git describe --tags --always --dirty)
 
 .PHONY: build
 build:


### PR DESCRIPTION
Had this around but never committed, Just to make `make iso` work locally, otherwise it fails as version from git dirty is not semver compliant:

```
 => ERROR [base-kairos 2/2] RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init  0.1s
------
 > [base-kairos 2/2] RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init     /kairos-i
nit -l debug -s install --version "de4b239-dirty" &&     /kairos-init -l debug -s init --version "de4b239-d
irty":
0.110 2025-10-22T08:40:08Z INF [7] Starting kairos-init version v0.6.1
0.110 2025-10-22T08:40:08Z DBG [7] values.BuildInfo{
0.110   Version: "v0.6.1",
0.110   GitCommit: "a437bd1",
0.110   GoVersion: "go1.25.2",
0.110 }
0.110 Error: error parsing version: Malformed version: de4b239-dirty
0.110 Usage:
0.110   kairos-init [flags]
0.110   kairos-init [command]
0.110
0.110 Available Commands:
0.110   completion  Generate the autocompletion script for the specified shell
0.110   help        Help about any command
0.110   steps-info  Get information about the steps
0.110   validate    Validate the system
0.110   version     Print the version of kairos-init and bundled binaries
0.110
0.110 Flags:
0.110       --fips                            use fips kairos binary versions. For FIPS 140-2 compliance im
ages
0.110   -h, --help                            help for kairos-init
0.110   -l, --level string                    set the log level (debug, info, warn, error, trace) (default
"info")
0.110   -m, --model string                    model to build for, like generic or rpi4 (default "generic")
0.110   -p, --provider strings                Provider plugin (repeatable)
0.110       --provider-$NAME-config string    Config for provider $NAME set by --provider/-p flag
0.110       --provider-$NAME-version string   Version for provider $NAME set by --provider/-p flag
0.110       --skip-step string,string,...     Skip one or more steps. Valid values are: branding, buildProv
ider, cleanup, cloudconfigs, grub, init, initramfsConfigs, initrd, install, installKernel, installPackages,
 kairosBinaries, kairosRelease, kernel, kubernetes, miscellaneous, providerBinaries, services, workarounds.
 You can pass multiple values separated by commas, for example: --skip-step initrd,workarounds
0.110   -s, --stage string                    set the stage to run (init, install, all) (default "all")
0.110   -x, --stage-extensions                enable stage extensions mode
0.110   -t, --trusted string                  init the system for Trusted Boot, changes bootloader to syste
md (default "false")
0.110   -v, --version string                  set a version number to use for the generated system. Its use
d to identify this system for upgrades and such. Required.
0.110
0.110 Use "kairos-init [command] --help" for more information about a command.
0.110
------
Dockerfile.init:9
--------------------
   8 |
   9 | >>> RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
  10 | >>>     /kairos-init -l debug -s install --version "${VERSION}" && \
  11 | >>>     /kairos-init -l debug -s init --version "${VERSION}"
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c /kairos-init -l debug -s install --version \"${VERSION}\" &&     /kairos-init -l debug -s init --version \"${VERSION}\"" did not complete successfully: exit code: 1
```