### PR TITLE
feat: Support building trusted boot images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,14 @@ AURORA_IMAGE ?= quay.io/kairos/auroraboot:v0.9.0
 TARGET ?= default
 JOBS ?= 24
 GIT_VERSION := v0.0.0-$(shell git describe --tags --always --dirty)
+BOOTLOADER ?= grub
 
 .PHONY: build
 build:
 	docker build --progress=plain \
 	--build-arg JOBS=${JOBS} \
 	--build-arg VERSION=$$(git describe --tags --always --dirty) \
+	--build-arg BOOTLOADER=${BOOTLOADER} \
 	-t ${IMAGE_NAME} \
 	--target ${TARGET} .
 


### PR DESCRIPTION
- Introduced libffi version 3.5.2 to the build process so python can be built with ctypes
- Build systemd-boot in a separate process
- Allow building for systemd bootloader with BOOTLOADER var in the makefile
- Finish the systemd-only target which provides a hadron image with no dracut or grub