### PR TITLE
feat: Add toolchain and grub build jobs to CI

### DIFF
--- a/.github/workflows/image_publish.yml
+++ b/.github/workflows/image_publish.yml
@@ -12,8 +12,74 @@ concurrency:
   group: ci-image-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
+  toolchain:
+    runs-on: oracle-24cpu-384gb-x86-64
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          buildkitd-config-inline: |
+            [worker.oci]
+              max-parallelism = 4
+      - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28fdb31ff34708d19615a74d67103ddc2ea9725c
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@032a4b3bda1b716928481836ac5bfe36e1feaad6
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}-toolchain
+          tags: |
+            type=semver,pattern={{raw}}
+            type=ref,event=branch
+          flavor: |
+            latest=auto
+            prefix=
+            suffix=
+      - name: Build and push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: toolchain
+          cache-from: type=gha,scope=hadron/ci-image-${{ github.ref_name }}
+          cache-to: type=gha,mode=max,scope=hadron/ci-image-${{ github.ref_name }}
+      - name: Build PR
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ttl.sh/hadron-container:${{ github.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: toolchain
+          cache-from: type=gha,scope=hadron/ci-image-main
   container:
     runs-on: oracle-24cpu-384gb-x86-64
+    needs:
+      - toolchain
     permissions:
       packages: write
       contents: read
@@ -85,7 +151,75 @@ jobs:
           platforms: linux/amd64
           target: container-test
           cache-from: type=gha,scope=hadron/ci-image-${{ github.ref_name }}
-  default:
+  hadron-grub:
+    runs-on: oracle-24cpu-384gb-x86-64
+    needs:
+      - container  # Take advantage of cached layers from the container build
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          buildkitd-config-inline: |
+            [worker.oci]
+              max-parallelism = 4
+      - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28fdb31ff34708d19615a74d67103ddc2ea9725c
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@032a4b3bda1b716928481836ac5bfe36e1feaad6
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}-grub
+          tags: |
+            type=semver,pattern={{raw}}
+            type=ref,event=branch
+          flavor: |
+            latest=auto
+            prefix=
+            suffix=
+      - name: Build and push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=hadron/ci-image-${{ github.ref_name }}
+          cache-to: type=gha,mode=max,scope=hadron/ci-image-${{ github.ref_name }}
+          build-args:
+            BOOTLOADER=grub
+      - name: Build PR
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ttl.sh/hadron-grub:${{ github.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=hadron/ci-image-main
+          build-args:
+            BOOTLOADER=grub
+  hadron:
     runs-on: oracle-24cpu-384gb-x86-64
     needs:
       - container  # Take advantage of cached layers from the container build
@@ -137,6 +271,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=hadron/ci-image-${{ github.ref_name }}
           cache-to: type=gha,mode=max,scope=hadron/ci-image-${{ github.ref_name }}
+          build-args:
+            BOOTLOADER=systemd
       - name: Build PR
         if: github.event_name == 'pull_request'
         uses: docker/build-push-action@v6
@@ -149,10 +285,12 @@ jobs:
           tags: ttl.sh/hadron:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=hadron/ci-image-main
+          build-args:
+            BOOTLOADER=systemd
   build:
     runs-on: ubuntu-latest
     needs:
-      - default
+      - hadron-grub
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
@@ -167,7 +305,7 @@ jobs:
           push: true
           tags: ttl.sh/hadron-init:${{ github.sha }}
           build-args: |
-            BASE_IMAGE=ttl.sh/hadron:${{ github.sha }}
+            BASE_IMAGE=ttl.sh/hadron-grub:${{ github.sha }}
             VERSION=v0.0.1-${{ github.sha }}
   build-iso:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -2614,7 +2614,7 @@ RUN rsync -aHAX --keep-dirlinks /binutils/. /merge
 
 
 
-FROM scratch AS full-toolchain
+FROM scratch AS toolchain
 COPY --from=full-toolchain-merge /merge /.
 
 ########################################################


### PR DESCRIPTION
- Introduced new jobs for building toolchain and grub images in the CI pipeline.
- Configured Docker Buildx for optimized builds with caching.
- Enabled conditional builds for pull requests and main branch pushes.

Now the main image pushed under hadron is the systemd one, I think we want to push the Trusted Boot image as the main one. The grub image is called hadron-grub
The toolchain is called hadron-toolchain