### PR TITLE
fix: Update image names for consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE_NAME ?= ghcr.io/kairos-io/hadron:main
+IMAGE_NAME ?= ghcr.io/kairos-io/hadron-default-trusted:main
 INIT_IMAGE_NAME ?= hadron-init
 AURORA_IMAGE ?= quay.io/kairos/auroraboot:v0.14.0-beta1
 TARGET ?= default
@@ -16,10 +16,10 @@ PROGRESS_FLAG = --progress=${PROGRESS}
 # we set it to the GRUB-specific image.
 # otherwise, we leave it as the default.
 ifeq ($(BOOTLOADER),grub)
-ifneq ($(IMAGE_NAME),ghcr.io/kairos-io/hadron:main)
+ifneq ($(IMAGE_NAME),ghcr.io/kairos-io/hadron-default-trusted:main)
   # User override, do nothing
 else
-  $(eval IMAGE_NAME := ghcr.io/kairos-io/hadron-grub:main)
+  $(eval IMAGE_NAME := ghcr.io/kairos-io/hadron-default-grub:main)
 endif
 endif
 


### PR DESCRIPTION
- Changed `IMAGE_NAME` from `ghcr.io/kairos-io/hadron:main` to `ghcr.io/kairos-io/hadron-default-trusted:main`
- Changed GRUB image name from `ghcr.io/kairos-io/hadron-grub:main` to `ghcr.io/kairos-io/hadron-default-grub:main` This change ensures that the image names reflect the default trusted configuration for better clarity and consistency in usage.

with the name change of the artifacts the makefile was pointing to an older version