### PR TITLE
feat: Increase buildkitd max-parallelism for improved performance

### DIFF
--- a/.github/workflows/image_publish.yml
+++ b/.github/workflows/image_publish.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           buildkitd-config-inline: |
             [worker.oci]
-              max-parallelism = 4
+              max-parallelism = 12
       - name: Log in to the Container registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@28fdb31ff34708d19615a74d67103ddc2ea9725c
@@ -94,7 +94,7 @@ jobs:
         with:
           buildkitd-config-inline: |
             [worker.oci]
-              max-parallelism = 4
+              max-parallelism = 12
       - name: Log in to the Container registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@28fdb31ff34708d19615a74d67103ddc2ea9725c
@@ -172,7 +172,7 @@ jobs:
         with:
           buildkitd-config-inline: |
             [worker.oci]
-              max-parallelism = 4
+              max-parallelism = 12
       - name: Log in to the Container registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@28fdb31ff34708d19615a74d67103ddc2ea9725c
@@ -245,7 +245,7 @@ jobs:
         with:
           buildkitd-config-inline: |
             [worker.oci]
-              max-parallelism = 4
+              max-parallelism = 12
       - name: Log in to the Container registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@28fdb31ff34708d19615a74d67103ddc2ea9725c


### PR DESCRIPTION
- Changed `max-parallelism` from 4 to 12 to enhance concurrency during image builds
- This adjustment aims to optimize build times and resource utilization