### PR TITLE
fix: Update image tags for consistency and clarity

### DIFF
--- a/.github/workflows/image_publish.yml
+++ b/.github/workflows/image_publish.yml
@@ -71,7 +71,6 @@ jobs:
           context: ./
           file: ./Dockerfile
           platforms: linux/amd64
-          push: true
           tags: ttl.sh/hadron-toolchain:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           target: toolchain
@@ -107,7 +106,7 @@ jobs:
         uses: docker/metadata-action@8d8c7c12f7b958582a5cb82ba16d5903cb27976a
         with:
           images: |
-            ghcr.io/${{ github.repository }}-container
+            ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{raw}}
             type=ref,event=branch
@@ -137,8 +136,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           platforms: linux/amd64
-          push: true
-          tags: ttl.sh/hadron-container:${{ github.sha }}
+          tags: ttl.sh/hadron:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           target: container
           cache-from: type=gha,scope=hadron/ci-image-main

--- a/.github/workflows/image_publish.yml
+++ b/.github/workflows/image_publish.yml
@@ -289,7 +289,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ttl.sh/hadron-${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-trusted:${{ github.sha }}
+          tags: ttl.sh/hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-trusted:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=hadron/ci-image-main
           build-args: |

--- a/.github/workflows/image_publish.yml
+++ b/.github/workflows/image_publish.yml
@@ -72,7 +72,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ttl.sh/hadron-container:${{ github.sha }}
+          tags: ttl.sh/hadron-toolchain:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           target: toolchain
           cache-from: type=gha,scope=hadron/ci-image-main
@@ -185,7 +185,7 @@ jobs:
         uses: docker/metadata-action@8d8c7c12f7b958582a5cb82ba16d5903cb27976a
         with:
           images: |
-            ghcr.io/${{ github.repository }}-${{ matrix.kernel }}-bios
+            ghcr.io/${{ github.repository }}${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-bios
           tags: |
             type=semver,pattern={{raw}}
             type=ref,event=branch
@@ -218,7 +218,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ttl.sh/hadron-${{ matrix.kernel }}-bios:${{ github.sha }}
+          tags: ttl.sh/hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-bios:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=hadron/ci-image-main
           build-args: |
@@ -258,7 +258,7 @@ jobs:
         uses: docker/metadata-action@8d8c7c12f7b958582a5cb82ba16d5903cb27976a
         with:
           images: |
-            ghcr.io/${{ github.repository }}-${{ matrix.kernel }}-trusted
+            ghcr.io/${{ github.repository }}${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-trusted
           tags: |
             type=semver,pattern={{raw}}
             type=ref,event=branch
@@ -291,13 +291,13 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ttl.sh/hadron-${{ matrix.kernel }}-trusted:${{ github.sha }}
+          tags: ttl.sh/hadron-${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-trusted:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=hadron/ci-image-main
           build-args: |
             BOOTLOADER=systemd
             KERNEL_TYPE=${{ matrix.kernel }}
-  build-bios:
+  build-kairos-bios:
     runs-on: ubuntu-latest
     needs:
       - hadron-bios
@@ -318,7 +318,7 @@ jobs:
             BASE_IMAGE=ttl.sh/hadron-cloud-bios:${{ github.sha }}
             VERSION=v0.0.1-${{ github.sha }}
             TRUSTED_BOOT=false
-  build-trusted:
+  build-kairos-trusted:
     runs-on: ubuntu-latest
     needs:
       - hadron-trusted
@@ -342,7 +342,7 @@ jobs:
   build-bios-iso:
     runs-on: ubuntu-latest
     needs:
-      - build-bios
+      - build-kairos-bios
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
@@ -366,7 +366,7 @@ jobs:
   build-trusted-iso:
     runs-on: ubuntu-latest
     needs:
-      - build-trusted
+      - build-kairos-trusted
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE_NAME ?= ghcr.io/kairos-io/hadron-default-trusted:main
+IMAGE_NAME ?= ghcr.io/kairos-io/hadron-trusted:main
 INIT_IMAGE_NAME ?= hadron-init
 AURORA_IMAGE ?= quay.io/kairos/auroraboot:v0.14.0-beta1
 TARGET ?= default
@@ -16,10 +16,10 @@ PROGRESS_FLAG = --progress=${PROGRESS}
 # we set it to the GRUB-specific image.
 # otherwise, we leave it as the default.
 ifeq ($(BOOTLOADER),grub)
-ifneq ($(IMAGE_NAME),ghcr.io/kairos-io/hadron-default-trusted:main)
+ifneq ($(IMAGE_NAME),ghcr.io/kairos-io/hadron-trusted:main)
   # User override, do nothing
 else
-  $(eval IMAGE_NAME := ghcr.io/kairos-io/hadron-default-grub:main)
+  $(eval IMAGE_NAME := ghcr.io/kairos-io/hadron-grub:main)
 endif
 endif
 


### PR DESCRIPTION
- Changed image tags in `image_publish.yml` to use `hadron-toolchain` and `hadron-trusted` for better clarity.
- Updated Makefile to reflect the new image naming convention.
- Ensured that the build dependencies are correctly referenced for the new image names.