### PR TITLE
fix: Restore default image in Dockerfile

### DIFF
--- a/.github/workflows/image_publish.yml
+++ b/.github/workflows/image_publish.yml
@@ -204,6 +204,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          target: default
           cache-from: type=gha,scope=hadron/ci-image-main
           cache-to: type=gha,mode=max,scope=hadron/ci-image-${{ github.ref_name }}
           build-args: |
@@ -220,6 +221,7 @@ jobs:
           push: true
           tags: ttl.sh/hadron-${{ matrix.kernel }}-bios:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
+          target: default
           cache-from: type=gha,scope=hadron/ci-image-main
           build-args: |
             BOOTLOADER=grub
@@ -279,6 +281,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=hadron/ci-image-main
           cache-to: type=gha,mode=max,scope=hadron/ci-image-${{ github.ref_name }}
+          target: default
           build-args: |
             BOOTLOADER=systemd
             KERNEL_TYPE=${{ matrix.kernel }}
@@ -293,6 +296,7 @@ jobs:
           push: true
           tags: ttl.sh/hadron-${{ matrix.kernel }}-trusted:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
+          target: default
           cache-from: type=gha,scope=hadron/ci-image-main
           build-args: |
             BOOTLOADER=systemd

--- a/Dockerfile
+++ b/Dockerfile
@@ -3204,11 +3204,6 @@ RUN systemd-sysusers
 ## Link /lib/firmware into /usr/local/lib/firmware for firmware loading
 RUN mkdir -p /usr/local/lib && ln -s /lib/firmware /usr/local/lib/firmware
 
-### final image
-FROM scratch AS default
-COPY --from=full-image-final / /
-CMD ["/bin/bash", "-l"]
-
 ## final image with debug
 FROM full-image-final AS debug
 
@@ -3222,3 +3217,7 @@ COPY files/verify_binaries.sh /verify_binaries.sh
 RUN chmod +x /verify_binaries.sh
 RUN /verify_binaries.sh
 
+### final image, last in case we call it without a target, it will build this one
+FROM scratch AS default
+COPY --from=full-image-final / /
+CMD ["/bin/bash", "-l"]


### PR DESCRIPTION
- Move the default target to last
- Set the docker build target in the CI to default
- This change allows the build process to default to the specified image when no target is provided.

Fixes: https://github.com/kairos-io/hadron/issues/89