### PR TITLE
fix: Update image names for clarity and consistency

### DIFF
--- a/.github/workflows/image_publish.yml
+++ b/.github/workflows/image_publish.yml
@@ -106,7 +106,7 @@ jobs:
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
         with:
           images: |
-            ghcr.io/${{ github.repository }}
+            ghcr.io/${{ github.repository }}-container
           tags: |
             type=semver,pattern={{raw}}
             type=ref,event=branch
@@ -136,7 +136,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           platforms: linux/amd64
-          tags: ttl.sh/hadron:${{ github.sha }}
+          tags: ttl.sh/hadron-container:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           target: container
           cache-from: type=gha,scope=hadron/ci-image-main
@@ -183,7 +183,7 @@ jobs:
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
         with:
           images: |
-            ghcr.io/${{ github.repository }}${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-bios
+            ghcr.io/${{ github.repository }}${{ matrix.kernel == 'cloud' && '-cloud' || '' }}
           tags: |
             type=semver,pattern={{raw}}
             type=ref,event=branch
@@ -217,7 +217,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ttl.sh/hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-bios:${{ github.sha }}
+          tags: ttl.sh/hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           target: default
           cache-from: type=gha,scope=hadron/ci-image-main
@@ -317,7 +317,7 @@ jobs:
           push: true
           tags: ttl.sh/hadron-init-bios:${{ github.sha }}
           build-args: |
-            BASE_IMAGE=ttl.sh/hadron-cloud-bios:${{ github.sha }}
+            BASE_IMAGE=ttl.sh/hadron-cloud:${{ github.sha }}
             VERSION=v0.0.1-${{ github.sha }}
             TRUSTED_BOOT=false
   build-kairos-trusted:


### PR DESCRIPTION
- Changed container names in `image_publish.yml` to include `-container` suffix for better identification.
- Drop the bios appendix from default images
- Updated `Makefile` to reflect changes in image naming conventions.
- Rework makefile to produce BIOS images by default

Fixes: https://github.com/kairos-io/kairos/issues/3789