### PR TITLE
fix: Update multipath-tools and related dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -264,14 +264,14 @@ ENV LIBAIO_VERSION=${LIBAIO_VERSION}
 RUN cd /sources/downloads && wget -q https://pagure.io/libaio/archive/libaio-${LIBAIO_VERSION}/libaio-libaio-${LIBAIO_VERSION}.tar.gz && mv libaio-libaio-${LIBAIO_VERSION}.tar.gz libaio.tar.gz
 
 ## lvm2
-ARG LVM2_VERSION=2.03.35
+ARG LVM2_VERSION=2.03.37
 ENV LVM2_VERSION=${LVM2_VERSION}
 
 RUN cd /sources/downloads && wget -q http://ftp-stud.fht-esslingen.de/pub/Mirrors/sourceware.org/lvm2/releases/LVM2.${LVM2_VERSION}.tgz && mv LVM2.${LVM2_VERSION}.tgz lvm2.tgz
 
 
 ## multipath-tools
-ARG MULTIPATH_TOOLS_VERSION=0.11.3
+ARG MULTIPATH_TOOLS_VERSION=0.13.0
 ENV MULTIPATH_TOOLS_VERSION=${MULTIPATH_TOOLS_VERSION}
 
 RUN cd /sources/downloads && wget -q https://github.com/opensvc/multipath-tools/archive/refs/tags/${MULTIPATH_TOOLS_VERSION}.tar.gz && mv ${MULTIPATH_TOOLS_VERSION}.tar.gz multipath-tools.tar.gz
@@ -290,7 +290,7 @@ ENV CMAKE_VERSION=${CMAKE_VERSION}
 RUN cd /sources/downloads && wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz && mv cmake-${CMAKE_VERSION}.tar.gz cmake.tar.gz
 
 ## urcu
-ARG URCU_VERSION=0.15.2
+ARG URCU_VERSION=0.15.3
 ENV URCU_VERSION=${URCU_VERSION}
 RUN cd /sources/downloads && wget -q https://lttng.org/files/urcu/userspace-rcu-${URCU_VERSION}.tar.bz2 && mv userspace-rcu-${URCU_VERSION}.tar.bz2 urcu.tar.bz2
 
@@ -1433,13 +1433,13 @@ RUN mv -v gmp-${GMP_VERSION} gdb/gmp
 RUN mv -v mpc-${MPC_VERSION} gdb/mpc
 WORKDIR /sources/gdb
 RUN ./configure --quiet ${COMMON_CONFIGURE_ARGS} \
-    --target=${TARGET} \
+    --host=${TARGET}  AR=${TARGET}-ar RANLIB=${TARGET}-ranlib NM=${TARGET}-nm CC=${TARGET}-gcc LD=${TARGET}-ld STRIP=${TARGET}-strip \
     --with-sysroot=/ \
     --disable-nls \
     --with-libexpat-prefix=/usr \
     --disable-multilib
-RUN make -s ARCH="${ARCH}" CROSS_COMPILE="${TARGET}-" -j${JOBS}
-RUN make -s ARCH="${ARCH}" CROSS_COMPILE="${TARGET}-" DESTDIR=/gdb install
+RUN make -j${JOBS}
+RUN make -j${JOBS} DESTDIR=/gdb install install-gdbserver
 
 
 ## dbus first pass without systemd support so we can build systemd afterwards
@@ -1923,17 +1923,21 @@ RUN make -s -s && make -s -s install DESTDIR=/iptables
 
 ## libaio for lvm2
 FROM rsync AS libaio
-
+COPY --from=bash /bash /bash
+RUN rsync -aHAX --keep-dirlinks  /bash/. /
 COPY --from=sources-downloader /sources/downloads/libaio.tar.gz /sources/
 RUN mkdir -p /libaio
 WORKDIR /sources
 RUN tar -xf libaio.tar.gz && mv libaio-* libaio
 WORKDIR /sources/libaio
 ENV CC=gcc
-RUN make -s -j${JOBS} && make -s -j${JOBS} install DESTDIR=/libaio
+# Avoid building the static libaio.a as we only need the shared one
+RUN sed -i '/install.*libaio.a/s/^/#/' src/Makefile
+RUN make -j${JOBS}
+RUN DESTDIR=/libaio make install
 
 ## lvm2 for dmsetup, devmapper and so on
-## We need to build it with systemd support so we can use it later with systemd rules and so on
+## TODO: build it with systemd support
 FROM rsync AS lvm2
 
 COPY --from=pkgconfig /pkgconfig /pkgconfig
@@ -2422,7 +2426,6 @@ RUN ./configure --disable-asciidoctor --disable-documentation --prefix=/usr
 RUN make -s -j${JOBS} && make -s -j${JOBS} install DESTDIR=/dracut
 
 
-## multipath-tools with systemd support
 ## lvm2 for dmsetup, devmapper and so on
 ## We need to build it with systemd support so we can use it later with systemd rules and so on
 ## This helps when a device is unlocked to makle the mapper show the device right away
@@ -2504,10 +2507,12 @@ WORKDIR /sources
 RUN tar -xf multipath-tools.tar.gz && mv multipath-tools-* multipath-tools
 WORKDIR /sources/multipath-tools
 ENV CC="gcc"
+COPY files/0001-multipathd-Dont-pthread_join-twice.patch /sources/multipath-tools/0001-multipathd-Dont-pthread_join-twice.patch
+RUN patch -p1 </sources/multipath-tools/0001-multipathd-Dont-pthread_join-twice.patch
 # Set lib to /lib so it works in initramfs as well
-RUN make -s -j${JOBS} WARN_ONLY=1 sysconfdir="/etc" configdir="/etc/multipath/conf.d" LIB=/lib
-RUN make -s -j${JOBS} WARN_ONLY=1 SYSTEMDPATH=/lib LIB=/lib install DESTDIR=/multipath-tools
-RUN make -s -j${JOBS} WARN_ONLY=1 LIB=/lib install
+RUN make -s -j${JOBS} sysconfdir="/etc" configdir="/etc/multipath/conf.d" LIB=/lib
+RUN make -s -j${JOBS} SYSTEMDPATH=/lib LIB=/lib install DESTDIR=/multipath-tools
+RUN make -s -j${JOBS} LIB=/lib install
 RUN rm -Rf /multipath/usr/share/man
 
 ## dbus second pass pass with systemd support, so we can have a working systemd and dbus
@@ -3232,6 +3237,8 @@ FROM full-image-final AS debug
 
 COPY --from=strace /strace /
 COPY --from=gdb-stage0 /gdb /
+COPY --from=python-build /python /
+RUN --mount=from=gcc-stage0,src=/sysroot/usr/lib,dst=/mnt,ro cp -a /mnt/libstdc++.so* /usr/lib/
 CMD ["/bin/bash", "-l"]
 
 ## Final verification stage

--- a/files/0001-multipathd-Dont-pthread_join-twice.patch
+++ b/files/0001-multipathd-Dont-pthread_join-twice.patch
@@ -1,0 +1,60 @@
+From ffcae852afb74948e85bcf9db62da20ac5896b35 Mon Sep 17 00:00:00 2001
+From: Itxaka <itxaka@kairos.io>
+Date: Thu, 4 Dec 2025 22:11:02 +0100
+Subject: [PATCH v2] multipathd: Dont pthread_join twice
+Content-Type: text/plain; charset="utf-8"
+
+Currently it seems that urcu would already call pthread_join when
+calling call_rcu_data_free since a couple of years ago (since version
+v0.14.0)[0] so calling pthread_join on the just released one is
+problematic under musl systems. It seems like under glibc this has
+several checks in place before trying to dereference the thread but
+under musl it has nothing in place to validate so this causes a coredump
+on program shutdown.
+
+This is currently present in all version when compiled under musl,
+running multipathd -d and sending a SIGTERM to it, you can see the
+coredump happening at this point in the code.
+
+The patch runs only the old behaviour in urcu older than 0.14.0 to
+maintain the same bahaviour. In higher versions its not neccesary so we
+skip it.
+
+[0] https://github.com/urcu/userspace-rcu/commit/1cf55ba47342156cdf25335264b9774a16e0bb2d
+
+Signed-off-by: Itxaka <itxaka@kairos.io>
+---
+ multipathd/main.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/multipathd/main.c b/multipathd/main.c
+index d11a8576..b30b151f 100644
+--- a/multipathd/main.c
++++ b/multipathd/main.c
+@@ -3739,18 +3739,21 @@ static struct call_rcu_data *mp_rcu_data;
+ 
+ static void cleanup_rcu(void)
+ {
+-	pthread_t rcu_thread;
+-
+ 	/* Wait for any pending RCU calls */
+ 	rcu_barrier();
+ 	if (mp_rcu_data != NULL) {
++#if (URCU_VERSION < 0x000E00)
++	        pthread_t rcu_thread;
+ 		rcu_thread = get_call_rcu_thread(mp_rcu_data);
++#endif
+ 		/* detach this thread from the RCU thread */
+ 		set_thread_call_rcu_data(NULL);
+ 		synchronize_rcu();
+ 		/* tell RCU thread to exit */
+ 		call_rcu_data_free(mp_rcu_data);
++#if (URCU_VERSION < 0x000E00)
+ 		pthread_join(rcu_thread, NULL);
++#endif
+ 	}
+ 	rcu_unregister_thread();
+ }
+-- 
+2.52.0
+


### PR DESCRIPTION
- Bump MULTIPATH_TOOLS_VERSION from 0.11.3 to 0.13.0
- Bump LVM2_VERSION from 2.03.35 to 2.03.37
- Bump URCU_VERSION from 0.15.2 to 0.15.3
- Adjust build commands for multipath-tools to ensure proper installation

Patch multipathd to avoid a coredump on cleanup.

Seems like while glibc is more careful about freeing a thread when the pthread_join is called, musl is not and calls to an already dereferenced pointer which causes a coredump.

checking the code seems like urcu already calls the pthread_join when call_rcu_data_free is called, so we are doing a double free on the same thread. Fix this by not calling the pthread_join again.

This patch was also sent to upstream to multipath directly as it fixes a real issue which also shows on other musl distros like alpine.

These updates address compatibility issues and improve functionality during cleanup processes.