### PR TITLE
fix: Update acceptance test and Makefile configuration

### DIFF
--- a/.github/workflows/image_publish.yml
+++ b/.github/workflows/image_publish.yml
@@ -369,7 +369,7 @@ jobs:
           mkdir build
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
           -v $PWD/build/:/output \
-          quay.io/kairos/auroraboot:v0.13.0 --debug build-iso --output /output/ \
+          quay.io/kairos/auroraboot:v0.16.1 --debug build-iso --output /output/ \
           --override-name kairos-hadron-bios-${{ github.sha }} \
           docker:ttl.sh/hadron-init-bios:${{ github.sha }}
       - name: Upload artifact
@@ -395,7 +395,7 @@ jobs:
           -v $PWD/tests/assets/keys:/keys \
           -v $PWD/build/:/output \
           -v $PWD/tests/assets/sysext/:/overlay \
-          quay.io/kairos/auroraboot:v0.14.0-beta1 --debug build-uki \
+          quay.io/kairos/auroraboot:v0.16.1 --debug build-uki \
           --output-dir /output/ --public-keys /keys \
           --tpm-pcr-private-key /keys/tpm2-pcr-private.pem \
           --sb-key /keys/db.key \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 IMAGE_NAME ?= ghcr.io/kairos-io/hadron:main
 INIT_IMAGE_NAME ?= hadron-init
-AURORA_IMAGE ?= quay.io/kairos/auroraboot:v0.16.0
+AURORA_IMAGE ?= quay.io/kairos/auroraboot:v0.16.1
 TARGET ?= default
 JOBS ?= $(shell nproc)
 HADRON_VERSION ?= $(shell git describe --tags --always --dirty)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 IMAGE_NAME ?= ghcr.io/kairos-io/hadron:main
 INIT_IMAGE_NAME ?= hadron-init
-AURORA_IMAGE ?= quay.io/kairos/auroraboot:v0.14.0-beta1
+AURORA_IMAGE ?= quay.io/kairos/auroraboot:v0.16.0
 TARGET ?= default
 JOBS ?= $(shell nproc)
 HADRON_VERSION ?= $(shell git describe --tags --always --dirty)

--- a/tests/acceptance_test.go
+++ b/tests/acceptance_test.go
@@ -57,7 +57,7 @@ var _ = Describe("kairos basic test", func() {
 
 	It("passes checks", Label("acceptance"), func() {
 		By("checking grubenv file", func() {
-			out, err := vm.Sudo("cat /oem/grub_oem_env")
+			out, err := vm.Sudo("cat /oem/grubenv")
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(ContainSubstring("foobarzz"))
 		})

--- a/tests/acceptance_test.go
+++ b/tests/acceptance_test.go
@@ -207,7 +207,7 @@ var _ = Describe("kairos basic test", func() {
 	})
 	It("resets", Label("reset"), func() {
 		Eventually(func() string {
-			out, _ := vm.Sudo("cat /oem/grub_oem_env")
+			out, _ := vm.Sudo("cat /oem/grubenv")
 			return out
 		}, 10*time.Minute, 1*time.Second).Should(
 			Or(
@@ -223,7 +223,7 @@ var _ = Describe("kairos basic test", func() {
 		vm.HasFile("/oem/test")
 		vm.HasFile("/usr/local/test")
 		By("Setting the next entry to statereset")
-		_, err = vm.Sudo("grub2-editenv /oem/grub_oem_env set next_entry=statereset")
+		_, err = vm.Sudo("grub2-editenv /oem/grubenv set next_entry=statereset")
 		Expect(err).ToNot(HaveOccurred())
 		By("Rebooting")
 		vm.Reboot()


### PR DESCRIPTION
- Changed the command in the acceptance test from `cat /oem/grub_oem_env` to `cat /oem/grubenv` for accuracy. This weas changed before due to a change in the agent newer version. As we went back to a previous version, this change is no longer needed for now.
- 
- Updated AURORA_IMAGE version from `v0.14.0-beta1` to `v0.16.0` to use the latest image.