### PR TITLE
fix: Update Dockerfile for systemd-bless-boot build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2344,6 +2344,8 @@ WORKDIR /sources/systemd
 ENV CFLAGS="$CFLAGS -D __UAPI_DEF_ETHHDR=0 -D _LARGEFILE64_SOURCE"
 ## Superhack to get tpm2-setup binary and service to build without having bootloader=enabled
 RUN sed -i "/'name' *: *'systemd-tpm2-setup'/,/},/s/'ENABLE_BOOTLOADER', *//" src/tpm2-setup/meson.build
+## Superhack to build systemd-bless-boot binary and generator
+RUN sed -i "/'conditions' *: *\[/,/\]/s/'ENABLE_BOOTLOADER',* *//g" src/bless-boot/meson.build
 ## Superhack to enable units that are linked to booloader build but we cant build them directly
 RUN sed -i "/'file' *: *'systemd-bless-boot.service.in'/,/},/s/'ENABLE_BOOTLOADER', *//" units/meson.build
 RUN sed -i "/'file' *: *'systemd-pcrextend@.service.in'/,/},/s/'ENABLE_BOOTLOADER', *//" units/meson.build


### PR DESCRIPTION
- Added a sed command to meson.build to remove 'ENABLE_BOOTLOADER' condition for systemd-bless-boot binary and generator.
- This change allows the systemd-bless-boot binary to build without the bootloader being enabled.


bless-boot is the service that marks an entry as good when it reaches the default boot target. Otherwise the entry is never marked goo and it can exhaust the retries thinking that its failing.