### PR TITLE
feat: Refactor Dockerfile to install real kernel headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ENV JOBS=${JOBS}
 ARG MUSSEL_VERSION="95dec40aee2077aa703b7abc7372ba4d34abb889"
 ENV MUSSEL_VERSION=${MUSSEL_VERSION}
 
-RUN apk update && apk add git bash wget bash perl build-base make patch busybox-static curl m4 xz texinfo bison gawk gzip zstd-dev coreutils bzip2 tar
+RUN apk update && apk add git bash wget bash perl build-base make patch busybox-static curl m4 xz texinfo bison gawk gzip zstd-dev coreutils bzip2 tar rsync
 RUN git clone https://github.com/firasuke/mussel.git && cd mussel && git checkout ${MUSSEL_VERSION} -b build
 RUN cd mussel && ./mussel ${ARCH} -k -l -o -p -s -T ${VENDOR}
 
@@ -484,7 +484,7 @@ EOT
 
 FROM make-stage0 AS kernel-headers-stage0
 ARG JOBS
-RUN apk add rsync
+
 COPY --from=sources-downloader /sources/downloads/linux.tar.xz /sources/
 
 WORKDIR /sources
@@ -505,8 +505,6 @@ RUN if [ ${ARCH} = "aarch64" ]; then \
 
 # Here we assemble our building image that we will use to build all the other packages, and assemble again from scratch+skeleton
 FROM stage0 AS stage1-merge
-
-RUN apk add rsync
 
 COPY --from=skeleton /sysroot /skeleton
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -482,9 +482,20 @@ RUN <<EOT bash
        make -s -j${JOBS} DESTDIR=/sysroot install ;
 EOT
 
-## This is a hack to avoid to need the kernel headers to compile things like busybox
-FROM alpine:${ALPINE_VERSION} AS alpine-hack
-RUN apk add linux-headers
+FROM make-stage0 AS kernel-headers-stage0
+ARG JOBS
+RUN apk add rsync
+COPY --from=sources-downloader /sources/downloads/linux.tar.xz /sources/
+
+WORKDIR /sources
+RUN tar -xf linux.tar.xz && mv linux-* kernel
+WORKDIR /sources/kernel
+# This installs the headers
+RUN if [ ${ARCH} = "aarch64" ]; then \
+    export ARCH=arm64; \
+    else \
+    export ARCH=x86_64;\
+    fi; make -s -j${JOBS} headers_install INSTALL_HDR_PATH=/linux-headers
 
 ########################################################
 #
@@ -519,18 +530,8 @@ RUN rsync -aHAX --keep-dirlinks /make/. /skeleton/
 COPY --from=binutils-stage0 /sysroot /binutils
 RUN rsync -aHAX --keep-dirlinks /binutils/. /skeleton/
 
-## This is a hack to avoid to need the kernel headers to compile things like busybox
-COPY --from=alpine-hack /usr/include/linux /linux
-RUN mkdir -p /skeleton/usr/include/linux && rsync -aHAX --keep-dirlinks  /linux/. /skeleton/usr/include/linux
-
-COPY --from=alpine-hack /usr/include/asm /asm
-RUN mkdir -p /skeleton/usr/include/asm && rsync -aHAX --keep-dirlinks  /asm/. /skeleton/usr/include/asm
-
-COPY --from=alpine-hack /usr/include/asm-generic /asm-generic
-RUN mkdir -p /skeleton/usr/include/asm-generic && rsync -aHAX --keep-dirlinks  /asm-generic/. /skeleton/usr/include/asm-generic
-
-COPY --from=alpine-hack /usr/include/mtd /mtd
-RUN mkdir -p /skeleton/usr/include/mtd && rsync -aHAX --keep-dirlinks  /mtd/. /skeleton/usr/include/mtd
+COPY --from=kernel-headers-stage0 /linux-headers /linux-headers
+RUN rsync -aHAX --keep-dirlinks  /linux-headers/. /skeleton/usr/
 
 # Provide ldconfig in the image
 COPY --from=sources-downloader /sources/downloads/aports.tar.gz /aports/aports.tar.gz


### PR DESCRIPTION
- Replaced the alpine-hack stage with kernel-headers-stage0 for better clarity and structure
- Added logic to handle architecture-specific header installation
- Improved the overall organization of the Dockerfile for easier maintenance

This makes our builds use the actual linux headers for the versions we are using later in the build instead of relaying in the alpine provided ones