### PR TITLE
fix: Update container names in multi-architecture build workflow

### DIFF
--- a/.github/workflows/build-multiarch-images.yml
+++ b/.github/workflows/build-multiarch-images.yml
@@ -278,7 +278,7 @@ jobs:
             ghcr.io/${{ github.repository }}-container:${{ github.ref_name }}-arm64
       - uses: vlaurin/action-ghcr-prune@v0.6.0
         with:
-          container: "${{ github.event.repository.name }}-toolchain"
+          container: "${{ github.event.repository.name }}-container"
           token: ${{ secrets.GITHUB_TOKEN }}
           dry-run: 'false'
           keep-tags-regexes: |
@@ -449,7 +449,7 @@ jobs:
             ghcr.io/${{ github.repository }}${{ matrix.kernel == 'cloud' && '-cloud' || '' }}${{ matrix.fips == 'fips' && '-fips' || '' }}:${{ github.ref_name }}-arm64
       - uses: vlaurin/action-ghcr-prune@v0.6.0
         with:
-          container: "${{ github.event.repository.name }}-toolchain"
+          container: "${{ github.event.repository.name }}${{ matrix.kernel == 'cloud' && '-cloud' || '' }}${{ matrix.fips == 'fips' && '-fips' || '' }}"
           token: ${{ secrets.GITHUB_TOKEN }}
           dry-run: 'false'
           keep-tags-regexes: |
@@ -606,7 +606,7 @@ jobs:
             ghcr.io/${{ github.repository }}${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-trusted:${{ github.ref_name }}-arm64
       - uses: vlaurin/action-ghcr-prune@v0.6.0
         with:
-          container: "${{ github.event.repository.name }}-toolchain"
+          container: "${{ github.event.repository.name }}${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-trusted"
           token: ${{ secrets.GITHUB_TOKEN }}
           dry-run: 'false'
           keep-tags-regexes: |


### PR DESCRIPTION
- Changed container name from `${{ github.event.repository.name }}-toolchain` to `${{ github.event.repository.name }}-container` for consistency.
- Adjusted container names in multiple steps to reflect the correct naming convention.

This makes it easy to keep our artifacts clean, as after merging the amd and arm64 images into one, we have the middle step containers around and this should get rid of them to avoid having unnnecessary tags lying around