### PR TITLE
Update coreutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -294,7 +294,7 @@ ARG PERL_VERSION=5.42.0
 RUN wget -q http://www.cpan.org/src/5.0/perl-${PERL_VERSION}.tar.xz -O perl.tar.xz
 
 ## coreutils
-ARG COREUTILS_VERSION=9.9
+ARG COREUTILS_VERSION=9.10
 RUN wget -q http://mirror.easyname.at/gnu/coreutils/coreutils-${COREUTILS_VERSION}.tar.xz -O coreutils.tar.xz
 
 ## findutils


### PR DESCRIPTION
https://lists.gnu.org/archive/html/coreutils-announce/2026-02/msg00000.html


Notable changes include:
- Options in man pages link directly into the full web docs
- timeout(1) now kills the command for all terminating signals
- paste(1) is now multi-byte character aware
- cp(1) fixes an unlikely infinite loop introduced in v9.9
- The multi-call binary is 3.2% smaller