### PR TITLE
fix: Update binutils version and adjust archive naming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -274,8 +274,8 @@ ARG MAKE_VERSION=4.4.1
 RUN wget -q https://mirror.netcologne.de/gnu/make/make-${MAKE_VERSION}.tar.gz -O make.tar.gz
 
 ## binutils (for stage0)
-ARG BINUTILS_VERSION=2.45.1
-RUN wget -q http://mirror.easyname.at/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.xz -O binutils.tar.xz
+ARG BINUTILS_VERSION=2.46.0
+RUN wget -q https://sourceware.org/pub/binutils/releases/binutils-${BINUTILS_VERSION}.tar.xz -O binutils.tar.xz
 
 ## popt
 ARG POPT_VERSION=1.19

--- a/Dockerfile
+++ b/Dockerfile
@@ -2266,6 +2266,10 @@ WORKDIR /sources
 RUN tar -xf shim.tar.bz2 && mv shim-* shim
 WORKDIR /sources/shim
 RUN mkdir -p /shim/usr/share/efi/
+# Fix the make.defaults to update the objcopy command to use the proper --output-target instead of --target as the flag has changed on binutils 2.46
+# When a new shim version is released, this will be fixed (current shim version is 16.1)
+# https://github.com/rhboot/shim/commit/c4665d282072df2ed8ab6ae1d5fa0de41e5db02f
+RUN sed -i 's/--target efi-app-$(ARCH)/--output-target efi-app-$(ARCH)/' Make.defaults
 # Install it to a temp folder as the dir struct is terrible
 # and we want it to be available at /usr/share/efi/shimXX.efi
 # TEMP workaround, we should add our paths into the sdk so agent and aurora both search for the proper shim path

--- a/updatecli.d/build-tools.yaml
+++ b/updatecli.d/build-tools.yaml
@@ -129,6 +129,8 @@ sources:
 
   binutils:
     # Much faster to query this thant to use the gittag which actually clones the repository fully
+    # Somehow they changed behaviour here. When the tag was 2.45 or 2.44 etc... they released the archives as
+    # 2.45.tar.gx or 2.44.tar.gz but ont his last tag they put 2.46 and released it as 2.46.0.tar.gz so we need to add a special case for this one
     kind: shell
     spec:
       command: |
@@ -140,6 +142,9 @@ sources:
       - replacer:
           from: '_'
           to: '.'
+      - replacer:
+          from: '^2\.46$'
+          to: '2.46.0'
       - sort:
           method: semver
 


### PR DESCRIPTION
- Changed `BINUTILS_VERSION` from 2.45.1 to 2.46.0 to use the latest release
- Added a special case in the build-tools.yaml to handle the new archive naming convention for version 2.46.0