### PR TITLE
feat: Add Dockerfiles for fwupd and GPG

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -14,6 +14,8 @@ jobs:
       matrix:
         extra-file:
           - "Dockerfile.git"
+          - "Dockerfile.gpg"
+          - "Dockerfile.fwupd"
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/examples/add-packages/Dockerfile.fwupd
+++ b/examples/add-packages/Dockerfile.fwupd
@@ -1,6 +1,6 @@
 FROM ghcr.io/kairos-io/hadron-toolchain:main AS downloader
 # Link /usr/bin/env to /bin/env because some build scripts have it hardcoded and we don't want to break them.
-# TODO: Move thos into the base images
+# TODO: Move this into the base images
 RUN ln -s /bin/env /usr/bin/env
 # TODO: No /tmp in the docker images, move to the base images?
 RUN mkdir -p /tmp
@@ -41,8 +41,7 @@ RUN curl -L https://github.com/sqlite/sqlite/archive/refs/tags/version-${SQLITE3
 ARG LIBFFI_VERSION=3.5.2
 RUN curl -L https://github.com/libffi/libffi/releases/download/v${LIBFFI_VERSION}/libffi-${LIBFFI_VERSION}.tar.gz -o libffi.tar.gz
 
-ARG SQLITE3_VERSION=3.51.2
-RUN curl -L https://github.com/sqlite/sqlite/archive/refs/tags/version-${SQLITE3_VERSION}.tar.gz -o sqlite3.tar.gz
+
 
 
 RUN tar -xf pcre2.tar.gz && mv pcre2-* pcre2
@@ -117,7 +116,7 @@ RUN make -s -j${JOBS}
 RUN make -s -j${JOBS} DESTDIR=/output install
 
 # Libffi is a runtime dep of fwupd
-# we haveit on the toolchain for building but not on the hadron image, so we need to build it and copy the libs to the final image if the binaries require it during runtime
+# we have it on the toolchain for building but not on the hadron image, so we need to build it and copy the libs to the final image if the binaries require it during runtime
 FROM downloader AS libffi
 WORKDIR /sources/libffi
 # --disable-multi-os-directory makes sure we dont install the libs under /usr/lib64

--- a/examples/add-packages/Dockerfile.fwupd
+++ b/examples/add-packages/Dockerfile.fwupd
@@ -1,0 +1,181 @@
+FROM ghcr.io/kairos-io/hadron-toolchain:main AS downloader
+# Link /usr/bin/env to /bin/env because some build scripts have it hardcoded and we don't want to break them.
+# TODO: Move thos into the base images
+RUN ln -s /bin/env /usr/bin/env
+# TODO: No /tmp in the docker images, move to the base images?
+RUN mkdir -p /tmp
+# Install it at the top so we dont need to reinstall on each target
+RUN pip3 install meson ninja jinja2
+# create the empty dir which will be the target of our installs on each target
+RUN mkdir -p /output
+WORKDIR /sources
+# fwupd
+ARG FWUPD_VERSION=2.0.17
+RUN curl -L https://github.com/fwupd/fwupd/releases/download/${FWUPD_VERSION}/fwupd-${FWUPD_VERSION}.tar.xz -o fwupd.tar.xz
+
+# glib
+ARG GLIB_VERSION=2.86.2
+RUN curl -L https://download.gnome.org/sources/glib/2.86/glib-${GLIB_VERSION}.tar.xz -o glib.tar.xz
+
+ARG PCRE2_VERSION=10.47
+RUN curl -L https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${PCRE2_VERSION}/pcre2-${PCRE2_VERSION}.tar.gz -o pcre2.tar.gz
+
+ARG LIBXMLB_VERSION=0.3.24
+RUN curl -L https://github.com/hughsie/libxmlb/releases/download/${LIBXMLB_VERSION}/libxmlb-${LIBXMLB_VERSION}.tar.xz -o libxmlb.tar.xz
+
+ARG LIBUSB_VERSION=1.0.29
+RUN curl -L https://github.com/libusb/libusb/releases/download/v${LIBUSB_VERSION}/libusb-${LIBUSB_VERSION}.tar.bz2 -o libusb.tar.bz2
+
+ARG LIBJCAT_VERSION=0.2.5
+RUN curl -L https://github.com/hughsie/libjcat/releases/download/${LIBJCAT_VERSION}/libjcat-${LIBJCAT_VERSION}.tar.xz -o libjcat.tar.xz
+
+ARG JSON_GLIB_VERSION=1.10.8
+RUN curl -L https://gitlab.gnome.org/GNOME/json-glib/-/archive/${JSON_GLIB_VERSION}/json-glib-${JSON_GLIB_VERSION}.tar.gz -o json-glib.tar.gz
+
+ARG GETTEXT_VERSION=1.0
+RUN curl -L https://ftp.gnu.org/pub/gnu/gettext/gettext-${GETTEXT_VERSION}.tar.gz -o gettext.tar.gz
+
+ARG SQLITE3_VERSION=3.51.2
+RUN curl -L https://github.com/sqlite/sqlite/archive/refs/tags/version-${SQLITE3_VERSION}.tar.gz -o sqlite3.tar.gz
+
+ARG LIBFFI_VERSION=3.5.2
+RUN curl -L https://github.com/libffi/libffi/releases/download/v${LIBFFI_VERSION}/libffi-${LIBFFI_VERSION}.tar.gz -o libffi.tar.gz
+
+ARG SQLITE3_VERSION=3.51.2
+RUN curl -L https://github.com/sqlite/sqlite/archive/refs/tags/version-${SQLITE3_VERSION}.tar.gz -o sqlite3.tar.gz
+
+
+RUN tar -xf pcre2.tar.gz && mv pcre2-* pcre2
+RUN tar -xf glib.tar.xz && mv glib-* glib
+RUN tar -xf libxmlb.tar.xz && mv libxmlb-* libxmlb
+RUN tar -xf libusb.tar.bz2 && mv libusb-* libusb
+RUN tar -xf json-glib.tar.gz && mv json-glib-* json-glib
+RUN tar -xf libjcat.tar.xz && mv libjcat-* libjcat
+RUN tar -xf gettext.tar.gz && mv gettext-* gettext
+RUN tar -xf fwupd.tar.xz && mv fwupd-* fwupd
+RUN tar -xf sqlite3.tar.gz && mv sqlite-version-* sqlite3
+RUN tar -xf libffi.tar.gz && mv libffi-* libffi
+
+
+
+FROM downloader AS pcre2
+WORKDIR /sources/pcre2
+RUN ./configure ${COMMON_CONFIGURE_ARGS} --enable-jit --enable-utf --enable-unicode-properties --disable-dependency-tracking
+RUN make -s -j${JOBS}
+RUN make -s -j${JOBS} install DESTDIR=/output
+
+FROM downloader AS glib2
+COPY --from=pcre2 /output/ /
+WORKDIR /sources/glib
+RUN meson setup buildDir ${COMMON_MESON_FLAGS} -Dselinux=disabled -Dxattr=false \
+    -Dlibmount=disabled -Dman-pages=disabled -Ddtrace=disabled -Dsystemtap=disabled -Dsysprof=disabled \
+    -Ddocumentation=false -Dtests=false -Dinstalled_tests=false -Dnls=disabled \
+    -Dglib_debug=disabled -Dglib_assert=false -Dglib_checks=false -Dlibelf=disabled -Dintrospection=disabled
+RUN DESTDIR=/output ninja -C buildDir install
+
+FROM downloader AS libxmlb
+COPY --from=glib2 /output /
+COPY --from=pcre2 /output /
+WORKDIR /sources/libxmlb
+RUN meson setup buildDir ${COMMON_MESON_FLAGS} -Dgtkdoc=false -Dtests=false \
+    -Dintrospection=false -Dstemmer=false -Dcli=false -Dlzma=disabled -Dzstd=disabled
+RUN DESTDIR=/output ninja -C buildDir install
+
+FROM downloader AS libusb
+WORKDIR /sources/libusb
+RUN ./configure ${COMMON_CONFIGURE_ARGS} --disable-dependency-tracking
+RUN make -s -j${JOBS} && make -s -j${JOBS} install DESTDIR=/output
+
+FROM downloader AS json-glib
+COPY --from=glib2 /output /
+COPY --from=pcre2 /output /
+WORKDIR /sources/json-glib
+RUN meson setup buildDir ${COMMON_MESON_FLAGS} -Dintrospection=disabled -Dtests=false -Dinstalled_tests=false -Dconformance=false
+RUN DESTDIR=/output ninja -C buildDir install
+
+FROM downloader AS gettext
+WORKDIR /sources/gettext
+RUN ./configure ${COMMON_CONFIGURE_ARGS} --enable-threads=posix --disable-java --disable-dependency-tracking --disable-examples
+RUN make -s -j${JOBS} && make -s -j${JOBS} install DESTDIR=/output
+# This contains a gazillion hello world examples in a gazillion languages, which we don't need.
+RUN rm -r /output/usr/share/doc
+
+FROM downloader AS sqlite3
+WORKDIR /sources/sqlite3
+ENV CFLAGS="${CFLAGS//-Os/-O2} -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_SECURE_DELETE -DSQLITE_ENABLE_UNLOCK_NOTIFY 	-DSQLITE_ENABLE_RTREE 	-DSQLITE_ENABLE_GEOPOLY 	-DSQLITE_USE_URI 	-DSQLITE_ENABLE_DBSTAT_VTAB 	-DSQLITE_SOUNDEX 	-DSQLITE_MAX_VARIABLE_NUMBER=250000"
+# remove lto flag from sqlite as it causes issues with linking later
+ENV COMMON_CONFIGURE_ARGS="${COMMON_CONFIGURE_ARGS//--enable-lto/}"
+RUN ./configure ${COMMON_CONFIGURE_ARGS} \
+		--enable-threadsafe \
+		--enable-session \
+		--enable-static \
+		--enable-fts3 \
+		--enable-fts4 \
+		--enable-fts5 \
+		--soname=legacy
+RUN make -s -j${JOBS}
+RUN make -s -j${JOBS} DESTDIR=/output install
+
+# Libffi is a runtime dep of fwupd
+# we haveit on the toolchain for building but not on the hadron image, so we need to build it and copy the libs to the final image if the binaries require it during runtime
+FROM downloader AS libffi
+WORKDIR /sources/libffi
+# --disable-multi-os-directory makes sure we dont install the libs under /usr/lib64
+# https://github.com/libffi/libffi/issues/127
+RUN ./configure ${COMMON_CONFIGURE_ARGS} --disable-docs --libdir=/usr/lib --disable-multi-os-directory
+RUN make -s -j${JOBS}
+RUN make -s -j${JOBS} install DESTDIR=/output
+
+FROM downloader AS libjcat
+COPY --from=glib2 /output /
+COPY --from=pcre2 /output /
+COPY --from=json-glib /output /
+WORKDIR /sources/libjcat
+RUN meson setup buildDir ${COMMON_MESON_FLAGS} -Dtests=false -Dintrospection=false -Dgnutls_ed25519=false -Dgnutls_pkcs7=false -Dgpg=false -Dopenssl_pkcs7=true
+RUN DESTDIR=/output ninja -C buildDir install
+
+FROM downloader AS fwupd
+COPY --from=pcre2 /output/ /
+COPY --from=glib2 /output/ /
+COPY --from=libxmlb /output/ /
+COPY --from=libusb /output/ /
+COPY --from=json-glib /output/ /
+COPY --from=gettext /output/ /
+COPY --from=sqlite3 /output/ /
+COPY --from=libjcat /output/ /
+WORKDIR /sources/fwupd
+# localstatedir is where it will store things like metadata
+RUN meson setup buildDir ${COMMON_MESON_FLAGS} --localstatedir=/usr/local -Dintrospection=disabled -Dbash_completion=false \
+    -Dblkid=disabled -Dbluez=disabled -Dcbor=disabled -Ddocs=disabled -Dfish_completion=false -Dgnutls=disabled \
+    -Dfirmware-packager=false -Dhsi=disabled -Dlibarchive=disabled -Dlibdrm=disabled -Dlibmnl=disabled -Dman=false \
+    -Dp2p_policy=none -Dpassim=disabled -Dpolkit=disabled -Dprotobuf=disabled -Dqubes=false -Dsupported_build=disabled -Dplugin_flashrom=disabled \
+    -Dtests=false -Dumockdev_tests=disabled -Dvalgrind=disabled -Db_lto=true -Dvendor_ids_dir=/usr/share/hwdata/ -Dplugin_uefi_capsule_splash=false
+RUN DESTDIR=/output ninja -C buildDir install
+
+
+
+# This will copy all the built dependencies to a single target, which we can then use as a base for the final image to have just one layer in the final images
+FROM scratch AS middle
+COPY --from=pcre2 /output/ /
+COPY --from=glib2 /output/ /
+COPY --from=libxmlb /output/ /
+COPY --from=libusb /output/ /
+COPY --from=json-glib /output/ /
+COPY --from=gettext /output/ /
+COPY --from=sqlite3 /output/ /
+COPY --from=fwupd /output/ /
+COPY --from=libffi /output/ /
+COPY --from=libjcat /output/ /
+
+# This target will copy the built binaries to a minimal image.
+# We can then use this as a layer on top of Hadron to extend it like
+# FROM ghcr.io/kairos-io/hadron:VERSION
+# COPY --from=OUR_IMAGE_NAME:TAG / /
+# Or create a sysextension with the help of Auroraboot (https://github.com/kairos-io/auroraboot)
+FROM scratch AS default
+COPY --link --from=middle / /
+
+
+## This one instead will pick the existing hadron image as base and add fwupd on top of it.
+FROM ghcr.io/kairos-io/hadron:main AS hadron-extension
+COPY --link --from=middle / /

--- a/examples/add-packages/Dockerfile.gpg
+++ b/examples/add-packages/Dockerfile.gpg
@@ -1,6 +1,6 @@
 FROM ghcr.io/kairos-io/hadron-toolchain:main AS downloader
 # Link /usr/bin/env to /bin/env because some build scripts have it hardcoded and we don't want to break them.
-# TODO: Move thos into the base images
+# TODO: Move this into the base images
 RUN ln -s /bin/env /usr/bin/env
 # TODO: No /tmp in the docker images, move to the base images?
 RUN mkdir -p /tmp
@@ -18,13 +18,13 @@ ARG LIBGCRYPT_VERSION=1.11.0
 RUN curl -L https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${LIBGCRYPT_VERSION}.tar.bz2 -o libgcrypt.tar.bz2
 
 ARG LIBASSUAN_VERSION=3.0.2
-RUN curl -L https://gnupg.org/ftp/gcrypt/libassuan/libassuan-3.0.2.tar.bz2 -o libassuan.tar.bz2
+RUN curl -L https://gnupg.org/ftp/gcrypt/libassuan/libassuan-${LIBASSUAN_VERSION}.tar.bz2 -o libassuan.tar.bz2
 
 ARG LIBKSBA_VERSION=1.6.7
-RUN curl -L https://gnupg.org/ftp/gcrypt/libksba/libksba-1.6.7.tar.bz2 -o libksba.tar.bz2
+RUN curl -L https://gnupg.org/ftp/gcrypt/libksba/libksba-${LIBKSBA_VERSION}.tar.bz2 -o libksba.tar.bz2
 
 ARG NPTH_VERSION=1.8
-RUN curl -L https://gnupg.org/ftp/gcrypt/npth/npth-1.8.tar.bz2 -o npth.tar.bz2
+RUN curl -L https://gnupg.org/ftp/gcrypt/npth/npth-${NPTH_VERSION}.tar.bz2 -o npth.tar.bz2
 
 ARG SQLITE3_VERSION=3.51.2
 RUN curl -L https://github.com/sqlite/sqlite/archive/refs/tags/version-${SQLITE3_VERSION}.tar.gz -o sqlite3.tar.gz
@@ -99,7 +99,7 @@ COPY --from=libksba /output/ /
 COPY --from=libassuan /output/ /
 COPY --from=npth /output/ /
 WORKDIR /sources/gnupg
-# remove --quiet flaf from configure args
+# remove --quiet flag from configure args
 ENV COMMON_CONFIGURE_ARGS="${COMMON_CONFIGURE_ARGS//--quiet/}"
 RUN ./configure ${COMMON_CONFIGURE_ARGS} --disable-dependency-tracking --disable-doc \
     --disable-gpgsm --disable-scdaemon --disable-dirmngr --disable-keyboxd --disable-tpm2d --disable-gpgtar \

--- a/examples/add-packages/Dockerfile.gpg
+++ b/examples/add-packages/Dockerfile.gpg
@@ -130,6 +130,6 @@ FROM scratch AS default
 COPY --link --from=middle / /
 
 
-## This one instead will pick the existing hadron image as base and add fwupd on top of it.
+## This one instead will pick the existing hadron image as base and add gpg on top of it.
 FROM ghcr.io/kairos-io/hadron:main AS hadron-extension
 COPY --link --from=middle / /

--- a/examples/add-packages/Dockerfile.gpg
+++ b/examples/add-packages/Dockerfile.gpg
@@ -1,0 +1,135 @@
+FROM ghcr.io/kairos-io/hadron-toolchain:main AS downloader
+# Link /usr/bin/env to /bin/env because some build scripts have it hardcoded and we don't want to break them.
+# TODO: Move thos into the base images
+RUN ln -s /bin/env /usr/bin/env
+# TODO: No /tmp in the docker images, move to the base images?
+RUN mkdir -p /tmp
+RUN mkdir -p /output
+
+WORKDIR /sources
+
+ARG GNUPG_VERSION=2.4.9
+RUN curl -L https://gnupg.org/ftp/gcrypt/gnupg/gnupg-${GNUPG_VERSION}.tar.bz2 -o gnupg.tar.bz2
+
+ARG LIBGPG_ERROR_VERSION=1.58
+RUN curl -L https://gnupg.org/ftp/gcrypt/gpgrt/libgpg-error-${LIBGPG_ERROR_VERSION}.tar.bz2 -o libgpg-error.tar.bz2
+
+ARG LIBGCRYPT_VERSION=1.11.0
+RUN curl -L https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${LIBGCRYPT_VERSION}.tar.bz2 -o libgcrypt.tar.bz2
+
+ARG LIBASSUAN_VERSION=3.0.2
+RUN curl -L https://gnupg.org/ftp/gcrypt/libassuan/libassuan-3.0.2.tar.bz2 -o libassuan.tar.bz2
+
+ARG LIBKSBA_VERSION=1.6.7
+RUN curl -L https://gnupg.org/ftp/gcrypt/libksba/libksba-1.6.7.tar.bz2 -o libksba.tar.bz2
+
+ARG NPTH_VERSION=1.8
+RUN curl -L https://gnupg.org/ftp/gcrypt/npth/npth-1.8.tar.bz2 -o npth.tar.bz2
+
+ARG SQLITE3_VERSION=3.51.2
+RUN curl -L https://github.com/sqlite/sqlite/archive/refs/tags/version-${SQLITE3_VERSION}.tar.gz -o sqlite3.tar.gz
+
+RUN tar -xf gnupg.tar.bz2 && mv gnupg-* gnupg
+RUN tar -xf libgpg-error.tar.bz2 && mv libgpg-error-* libgpg-error
+RUN tar -xf libgcrypt.tar.bz2 && mv libgcrypt-* libgcrypt
+RUN tar -xf libassuan.tar.bz2 && mv libassuan-* libassuan
+RUN tar -xf libksba.tar.bz2 && mv libksba-* libksba
+RUN tar -xf npth.tar.bz2 && mv npth-* npth
+RUN tar -xf sqlite3.tar.gz && mv sqlite-version-* sqlite3
+
+
+
+FROM downloader AS sqlite3
+WORKDIR /sources/sqlite3
+ENV CFLAGS="${CFLAGS//-Os/-O2} -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_SECURE_DELETE -DSQLITE_ENABLE_UNLOCK_NOTIFY 	-DSQLITE_ENABLE_RTREE 	-DSQLITE_ENABLE_GEOPOLY 	-DSQLITE_USE_URI 	-DSQLITE_ENABLE_DBSTAT_VTAB 	-DSQLITE_SOUNDEX 	-DSQLITE_MAX_VARIABLE_NUMBER=250000"
+# remove lto flag from sqlite as it causes issues with linking later
+ENV COMMON_CONFIGURE_ARGS="${COMMON_CONFIGURE_ARGS//--enable-lto/}"
+RUN ./configure ${COMMON_CONFIGURE_ARGS} \
+		--enable-threadsafe \
+		--enable-session \
+		--enable-static \
+		--enable-fts3 \
+		--enable-fts4 \
+		--enable-fts5 \
+		--soname=legacy
+RUN make -s -j${JOBS}
+RUN make -s -j${JOBS} DESTDIR=/output install
+
+
+FROM downloader AS libgpg-error
+WORKDIR /sources/libgpg-error
+RUN ./configure ${COMMON_CONFIGURE_ARGS} --disable-dependency-tracking --disable-doc --disable-tests
+RUN make -s -j${JOBS} && make -s -j${JOBS} install DESTDIR=/output
+
+
+FROM downloader AS libgcrypt
+COPY --from=libgpg-error /output/ /
+WORKDIR /sources/libgcrypt
+RUN ./configure ${COMMON_CONFIGURE_ARGS} --disable-dependency-tracking --disable-doc --disable-tests
+RUN make -s -j${JOBS}
+RUN make -s -j${JOBS} install DESTDIR=/output
+
+FROM downloader AS libassuan
+COPY --from=libgpg-error /output/ /
+WORKDIR /sources/libassuan
+RUN ./configure ${COMMON_CONFIGURE_ARGS} --disable-dependency-tracking --disable-doc --disable-tests
+RUN make -s -j${JOBS}
+RUN make -s -j${JOBS} install DESTDIR=/output
+
+FROM downloader AS libksba
+COPY --from=libgpg-error /output/ /
+WORKDIR /sources/libksba
+RUN ./configure ${COMMON_CONFIGURE_ARGS} --disable-dependency-tracking --disable-doc --disable-tests
+RUN make -s -j${JOBS}
+RUN make -s -j${JOBS} install DESTDIR=/output
+
+FROM downloader AS npth
+COPY --from=libgpg-error /output/ /
+WORKDIR /sources/npth
+RUN ./configure ${COMMON_CONFIGURE_ARGS} --disable-dependency-tracking --disable-doc --disable-tests
+RUN make -s -j${JOBS}
+RUN make -s -j${JOBS} install DESTDIR=/output
+
+# gpg required to verify the signatures
+FROM downloader AS gpg
+COPY --from=sqlite3 /output/ /
+COPY --from=libgpg-error /output/ /
+COPY --from=libgcrypt /output/ /
+COPY --from=libksba /output/ /
+COPY --from=libassuan /output/ /
+COPY --from=npth /output/ /
+WORKDIR /sources/gnupg
+# remove --quiet flaf from configure args
+ENV COMMON_CONFIGURE_ARGS="${COMMON_CONFIGURE_ARGS//--quiet/}"
+RUN ./configure ${COMMON_CONFIGURE_ARGS} --disable-dependency-tracking --disable-doc \
+    --disable-gpgsm --disable-scdaemon --disable-dirmngr --disable-keyboxd --disable-tpm2d --disable-gpgtar \
+    --disable-tofu --disable-libdns --disable-photo-viewers --disable-card-support --disable-ccid-driver --disable-ntbtls \
+    --disable-ldap --disable-nls --disable-tests --disable-wks-tools
+RUN make -s -j${JOBS}
+RUN make -s -j${JOBS} install DESTDIR=/output
+
+
+
+# This will copy all the built dependencies to a single target, which we can then use as a base for the final image to have just one layer in the final images
+FROM scratch AS middle
+COPY --from=sqlite3 /output/ /
+COPY --from=libgpg-error /output/ /
+COPY --from=libgcrypt /output/ /
+COPY --from=libksba /output/ /
+COPY --from=libassuan /output/ /
+COPY --from=npth /output/ /
+COPY --from=gpg /output/ /
+
+
+# This target will copy the built binaries to a minimal image.
+# We can then use this as a layer on top of Hadron to extend it like
+# FROM ghcr.io/kairos-io/hadron:VERSION
+# COPY --from=OUR_IMAGE_NAME:TAG / /
+# Or create a sysextension with the help of Auroraboot (https://github.com/kairos-io/auroraboot)
+FROM scratch AS default
+COPY --link --from=middle / /
+
+
+## This one instead will pick the existing hadron image as base and add fwupd on top of it.
+FROM ghcr.io/kairos-io/hadron:main AS hadron-extension
+COPY --link --from=middle / /


### PR DESCRIPTION
- Introduced `Dockerfile.fwupd` for building fwupd with necessary dependencies.
- Added `Dockerfile.gpg` for building GPG and its required libraries.
- Updated `examples.yml` to include new Dockerfiles in the build matrix.