### PR TITLE
fix: Update version filters in configuration files

### DIFF
--- a/updatecli.d/build-tools.yaml
+++ b/updatecli.d/build-tools.yaml
@@ -143,7 +143,7 @@ sources:
           from: '_'
           to: '.'
       - replacer:
-          from: '^2\.46$'
+          from: '2.46'
           to: '2.46.0'
       - sort:
           method: semver

--- a/updatecli.d/misc-tools.yaml
+++ b/updatecli.d/misc-tools.yaml
@@ -7,9 +7,10 @@ sources:
     spec:
       owner: python
       repository: cpython
-    versionfilter:
-      kind: semver
-      pattern: '*'
+      versionfilter:
+        kind: regex/semver
+        regex: '^v?(\d+\.\d+\.\d+)$'
+        pattern: '*'
     transformers:
       - trimprefix: v
 


### PR DESCRIPTION
- Changed `from` value in `build-tools.yaml` from '^2\.46$' to '2.46' for better regex compatibility
- Updated `versionfilter` in `misc-tools.yaml` to use regex for semantic versioning