### PR TITLE
fix: Update SYSTEMD_VERSION to 260 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN wget -q https://ftpmirror.gnu.org/gawk/gawk-${GAWK_VERSION}.tar.xz -O gawk.t
 ARG CA_CERTIFICATES_VERSION=20251003
 RUN wget -q https://gitlab.alpinelinux.org/alpine/ca-certificates/-/archive/${CA_CERTIFICATES_VERSION}/ca-certificates-${CA_CERTIFICATES_VERSION}.tar.bz2 -O ca-certificates.tar.bz2
 
-ARG SYSTEMD_VERSION=259.5
+ARG SYSTEMD_VERSION=260
 RUN cd /sources/downloads && wget -q https://github.com/systemd/systemd/archive/refs/tags/v${SYSTEMD_VERSION}.tar.gz -O systemd.tar.gz
 
 ARG LIBCAP_VERSION=2.77
@@ -2411,7 +2411,6 @@ RUN /usr/bin/meson setup buildDir \
       -D default-dnssec=no    \
       -D firstboot=false      \
       -D sysusers=true -D install-tests=false  -D tests=false -D fuzz-tests=false \
-      -D integration-tests=false \
       -D kernel-install=false \
       -D ukify=false \
       -D ldconfig=false       \


### PR DESCRIPTION
- Changed `SYSTEMD_VERSION` from 259.5 to 260 to align with the latest release
- This update ensures that the Docker image uses the most recent version of systemd for improved features and security