### PR TITLE
fix: Update sqlite configuration for version filtering

### DIFF
--- a/updatecli.d/misc-tools.yaml
+++ b/updatecli.d/misc-tools.yaml
@@ -15,13 +15,14 @@ sources:
       - trimprefix: v
 
   sqlite3:
-    kind: githubrelease
+    kind: gittag
     spec:
-      owner: sqlite
-      repository: sqlite
+      url: https://github.com/sqlite/sqlite.git
+      lsremote: true
       versionfilter:
-        kind: regex
-        pattern: '^version-[0-9]+\.[0-9]+\.[0-9]+$'
+        kind: regex/semver
+        regex: '^version-([0-9]+\.[0-9]+\.[0-9]+)$'
+        pattern: '*'
     transformers:
       - trimprefix: version-
 


### PR DESCRIPTION
- Changed `kind` from `githubrelease` to `gittag` for better compatibility
- Updated `url` to point directly to the SQLite GitHub repository
- Modified `versionfilter` to use `regex/semver` for improved version matching
- Enabled `lsremote` to allow remote version listing

This avoid downgrading to older versions due to a mismatch in the tags