### PR TITLE
feat: Enhance Dockerfile for multi-architecture support

### DIFF
--- a/examples/add-packages/Dockerfile.nvidia
+++ b/examples/add-packages/Dockerfile.nvidia
@@ -2,12 +2,15 @@
 # Its very important that you use the toolchain image at the same version as the Hadron image you want to extend
 # nvidia modules use the base kernel build to build the modules (Kbuild) so it needs to match the exact version kernel you
 # are going to be run, otherwise it will mismatch and not load the modules during runtime
-ARG HADRON_VERSION=0.0.4
+ARG HADRON_VERSION=v0.0.4
+ARG BASE_IMAGE=ghcr.io/kairos-io/hadron
 ARG JOBS
 ARG NVIDIA_VERSION=580.126.20
+ARG TARGETARCH
 
-FROM ghcr.io/kairos-io/hadron-toolchain:v${HADRON_VERSION} AS modules-builder
+FROM ghcr.io/kairos-io/hadron-toolchain:${HADRON_VERSION} AS modules-builder
 ARG JOBS
+ARG TARGETARCH
 WORKDIR /build
 # kernel version is stored under /usr/share/kernel-misc/kernel-version file
 # Pull kernel sources so we can build the modules
@@ -18,8 +21,8 @@ RUN cp /usr/share/kernel-misc/kernel-config .config
 # Disable module signing cleanly
 RUN ./scripts/config --disable MODULE_SIG
 RUN ./scripts/config --disable MODULE_SIG_ALL
-RUN ARCH=${BUILD_ARCH} make -s olddefconfig
-RUN ARCH=${BUILD_ARCH} make -s -j${JOBS} modules_prepare
+RUN ARCH=${TARGETARCH} make -s olddefconfig
+RUN ARCH=${TARGETARCH} make -s -j${JOBS} modules_prepare
 RUN cp /usr/share/kernel-misc/Module.symvers .
 ARG NVIDIA_VERSION
 WORKDIR /build
@@ -28,8 +31,8 @@ RUN tar -xf nvidia.tar.gz && rm nvidia.tar.gz && mv open-gpu-kernel-modules-${NV
 WORKDIR /build/nvidia-modules
 ENV CFLAGS="-Os -pipe"
 ENV LDFLAGS="--gc-sections --as-needed"
-RUN ARCH=${BUILD_ARCH} KERNEL_UNAME="$(cat /usr/share/kernel-misc/kernel-release)" SYSSRC=/build/linux SYSOUT=/build/linux make -s -j${JOBS} modules
-RUN ARCH=${BUILD_ARCH} KERNEL_UNAME="$(cat /usr/share/kernel-misc/kernel-release)" SYSSRC=/build/linux SYSOUT=/build/linux ZSTD_CLEVEL=19 INSTALL_MOD_PATH="/output" INSTALL_MOD_STRIP=1 DEPMOD=true make -s -j${JOBS} modules_install
+RUN ARCH=${TARGETARCH} KERNEL_UNAME="$(cat /usr/share/kernel-misc/kernel-release)" SYSSRC=/build/linux SYSOUT=/build/linux make -s -j${JOBS} modules
+RUN ARCH=${TARGETARCH} KERNEL_UNAME="$(cat /usr/share/kernel-misc/kernel-release)" SYSSRC=/build/linux SYSOUT=/build/linux ZSTD_CLEVEL=19 INSTALL_MOD_PATH="/output" INSTALL_MOD_STRIP=1 DEPMOD=true make -s -j${JOBS} modules_install
 
 # Create a separate stage to extract the NVIDIA userspace components, which we can then add to the Hadron image as well.
 # As the nvdia userspace components are linked against glibc, we also need to copy the glibc runtime libraries to ensure they can run properly in the musl-based Hadron image.
@@ -55,9 +58,13 @@ RUN apt-get update && \
 WORKDIR /work
 
 # Download NVIDIA redistributable driver archive
-RUN curl -L \
-  https://developer.download.nvidia.com/compute/nvidia-driver/redist/nvidia_driver/linux-x86_64/nvidia_driver-linux-x86_64-${NVIDIA_VERSION}-archive.tar.xz \
-  -o nvidia.tar.xz
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+    curl -L https://developer.download.nvidia.com/compute/nvidia-driver/redist/nvidia_driver/linux-x86_64/nvidia_driver-linux-x86_64-${NVIDIA_VERSION}-archive.tar.xz -o nvidia.tar.xz; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+    curl -L https://developer.download.nvidia.com/compute/nvidia-driver/redist/nvidia_driver/linux-sbsa/nvidia_driver-linux-sbsa-${NVIDIA_VERSION}-archive.tar.xz -o nvidia.tar.xz; \
+    else echo "Unsupported architecture: $TARGETARCH" && exit 1; \
+    fi
 
 RUN tar -xf nvidia.tar.xz --strip-components=1 && rm nvidia.tar.xz
 
@@ -105,8 +112,14 @@ RUN cp -a sbin/nvidia-cuda-mps-control ${OUTPUT}/usr/bin/
 
 # ---- Copy glibc runtime ----
 RUN set -eux; \
-    GLIBC=/lib/x86_64-linux-gnu; \
-    cp -L $GLIBC/ld-linux-x86-64.so.2 ${OUTPUT}/usr/lib/; \
+    if [ "$TARGETARCH" = "amd64" ]; then \
+        ARCH="x86-64"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        ARCH="aarch64"; \
+    else echo "Unsupported architecture: $TARGETARCH" && exit 1; \
+    fi; \
+    GLIBC=/lib/${ARCH}-linux-gnu; \
+    cp -L $GLIBC/ld-linux-${ARCH}.so* ${OUTPUT}/usr/lib/; \
     cp -L $GLIBC/libc.so.6 ${OUTPUT}/usr/libc/lib/; \
     cp -L $GLIBC/libpthread.so.0 ${OUTPUT}/usr/libc/lib/; \
     cp -L $GLIBC/libm.so.6 ${OUTPUT}/usr/libc/lib/; \
@@ -140,6 +153,6 @@ RUN echo "blacklist nouveau" > ${OUTPUT}/etc/modprobe.d/blacklist-nouveau.conf
 FROM scratch AS default
 COPY --from=builder /output/ /
 
-FROM ghcr.io/kairos-io/hadron:v${HADRON_VERSION} AS hadron-extension
+FROM ${BASE_IMAGE}:${HADRON_VERSION} AS hadron-extension
 COPY --link --from=modules-builder /output/ /usr/
 COPY --link --from=nvidia-builder /output/ /


### PR DESCRIPTION
- Added `TARGETARCH` argument to support building for different architectures (amd64, arm64)
- Updated build commands to use `TARGETARCH` instead of `BUILD_ARCH`
- Modified NVIDIA driver download logic to handle architecture-specific URLs
- Adjusted glibc runtime copying based on architecture