### PR TITLE
feat: Update util-linux and coreutils versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1452,8 +1452,7 @@ RUN meson setup buildDir --prefix=/usr --buildtype=minsize -Dstrip=true \
     -Dbuild-uuidd=disabled -Dbuild-libsmartcols=disabled -Dbtrfs=disabled -Dbuild-plymouth-support=disabled \
     -Dnls=disabled -Dbuild-minix=disabled -Dbuild-cramfs=disabled -Dbuild-bfs=disabled -Dprogram-tests=false \
     -Dfs-search-path-extra=/usr/sbin -Dvendordir=/usr/lib
-
-RUN DESTDIR=/dbus ninja -j${JOBS} -C buildDir install
+RUN DESTDIR=/util-linux ninja -j${JOBS} -C buildDir install
 
 
 ## gperf

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ ARG LIBCAP_VERSION=2.78
 RUN wget -q https://kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-${LIBCAP_VERSION}.tar.xz -O libcap.tar.xz
 
 FROM sources-downloader-base AS util-linux-download
-ARG UTIL_LINUX_VERSION=2.41.3
+ARG UTIL_LINUX_VERSION=2.42
 RUN UTIL_LINUX_VERSION_MAJOR="${UTIL_LINUX_VERSION%%.*}" \
     && UTIL_LINUX_VERSION_MINOR="${UTIL_LINUX_VERSION#*.}"; UTIL_LINUX_VERSION_MINOR="${UTIL_LINUX_VERSION_MINOR%.*}" \
     && wget -q https://www.kernel.org/pub/linux/utils/util-linux/v${UTIL_LINUX_VERSION_MAJOR}.${UTIL_LINUX_VERSION_MINOR}/util-linux-${UTIL_LINUX_VERSION}.tar.xz -O util-linux.tar.xz
@@ -325,7 +325,7 @@ ARG PERL_VERSION=5.42.1
 RUN wget -q https://github.com/Perl/perl5/archive/refs/tags/v${PERL_VERSION}.tar.gz -O perl.tar.gz
 
 FROM sources-downloader-base AS coreutils-download
-ARG COREUTILS_VERSION=9.10
+ARG COREUTILS_VERSION=9.11
 RUN wget -q http://mirror.easyname.at/gnu/coreutils/coreutils-${COREUTILS_VERSION}.tar.xz -O coreutils.tar.xz
 
 FROM sources-downloader-base AS findutils-download
@@ -1430,33 +1430,31 @@ RUN make -s -j${JOBS} -l${MAX_LOAD} install 2>&1
 
 
 ## util-linux
-FROM bash AS util-linux
+FROM python-build AS util-linux
+ARG JOBS
+RUN pip3 install meson ninja
+RUN mkdir -p /util-linux
+COPY --from=bison /bison /
+COPY --from=flex /flex /
+COPY --from=m4 /m4 /
+COPY --from=libcap /libcap /libcap
+RUN rsync -aHAX --keep-dirlinks  /libcap/. /
+COPY --from=coreutils /coreutils /coreutils
+RUN rsync -aHAX --keep-dirlinks  /coreutils/. /
+WORKDIR /sources
+COPY --from=sources-downloader /sources/downloads/util-linux.tar.xz .
+RUN tar -xf util-linux.tar.xz && mv util-linux-* util-linux
+WORKDIR /sources/util-linux
+# This is fixed on master so drop it on next version
+COPY patches/util-linux-musl-AT_HANDLE_FID.patch .
+RUN patch -p1 < util-linux-musl-AT_HANDLE_FID.patch
+RUN meson setup buildDir --prefix=/usr --buildtype=minsize -Dstrip=true \
+    -Dbuild-uuidd=disabled -Dbuild-libsmartcols=disabled -Dbtrfs=disabled -Dbuild-plymouth-support=disabled \
+    -Dnls=disabled -Dbuild-minix=disabled -Dbuild-cramfs=disabled -Dbuild-bfs=disabled -Dprogram-tests=false \
+    -Dfs-search-path-extra=/usr/sbin -Dvendordir=/usr/lib
 
-COPY --from=sources-downloader /sources/downloads/util-linux.tar.xz /sources/
+RUN DESTDIR=/dbus ninja -j${JOBS} -C buildDir install
 
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh && mkdir -p /sources && cd /sources && tar -xf util-linux.tar.xz && \
-    mv util-linux-* util-linux && \
-    cd util-linux && mkdir -p /util-linux && ./configure ${COMMON_CONFIGURE_ARGS} --disable-dependency-tracking  --prefix=/usr \
-    --libdir=/usr/lib \
-    --disable-silent-rules \
-    --enable-newgrp \
-    --disable-uuidd \
-    --disable-liblastlog2 \
-    --disable-nls \
-    --disable-kill \
-    --disable-chfn-chsh \
-    --with-vendordir=/usr/lib \
-    --enable-fs-paths-extra=/usr/sbin \
-    --disable-pam-lastlog2 \
-    --disable-asciidoc \
-    --disable-poman \
-    --disable-minix \
-    --disable-cramfs \
-    --disable-bfs \
-    --without-python \
-    --with-sysusersdir=/usr/lib/sysusers.d/ \
-    && make -s -j${JOBS} -l${MAX_LOAD} DESTDIR=/util-linux && \
-    make -s -j${JOBS} -l${MAX_LOAD} DESTDIR=/util-linux install && make -s -j${JOBS} -l${MAX_LOAD} install
 
 ## gperf
 FROM stage1 AS gperf

--- a/patches/util-linux-musl-AT_HANDLE_FID.patch
+++ b/patches/util-linux-musl-AT_HANDLE_FID.patch
@@ -1,0 +1,24 @@
+From 5452239f6e69d2d3aaa427d2d2253247cfb7cb7b Mon Sep 17 00:00:00 2001
+From: Aleksi Hannula <ahannula4+nixgit@gmail.com>
+Date: Tue, 7 Apr 2026 14:52:16 +0300
+Subject: [PATCH] nsenter: Fix AT_HANDLE_FID on musl
+
+Signed-off-by: Aleksi Hannula <ahannula4+nixgit@gmail.com>
+---
+ sys-utils/nsenter.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/sys-utils/nsenter.c b/sys-utils/nsenter.c
+index e10ba9cf90a..98507958c0f 100644
+--- a/sys-utils/nsenter.c
++++ b/sys-utils/nsenter.c
+@@ -29,6 +29,9 @@
+ #ifdef HAVE_LINUX_NSFS_H
+ # include <linux/nsfs.h>
+ #endif
++#ifndef AT_HANDLE_FID
++# define AT_HANDLE_FID 0x200
++#endif
+ #ifndef NS_GET_USERNS
+ # define NS_GET_USERNS           _IO(0xb7, 0x1)
+ #endif


### PR DESCRIPTION
- Bumped `UTIL_LINUX_VERSION` from 2.41.3 to 2.42
- Bumped `COREUTILS_VERSION` from 9.10 to 9.11
- Added patch for `nsenter` to fix `AT_HANDLE_FID` on musl. Fixed in master already so no patch needed from our side to upstream.
- Move util-linux build from make to meson