### PR TITLE
feat: Update rsync version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,8 @@ ARG CURL_VERSION=8.19.0
 RUN wget -q https://curl.se/download/curl-${CURL_VERSION}.tar.gz -O curl.tar.gz
 
 FROM sources-downloader-base AS rsync-download
-ARG RSYNC_VERSION=3.4.1
-RUN wget -q https://download.samba.org/pub/rsync/rsync-${RSYNC_VERSION}.tar.gz -O rsync.tar.gz
+ARG RSYNC_VERSION=3.4.2
+RUN wget -q https://github.com/RsyncProject/rsync/releases/download/v${RSYNC_VERSION}/rsync-${RSYNC_VERSION}.tar.gz -O rsync.tar.gz
 
 FROM sources-downloader-base AS xxhash-download
 ARG XXHASH_VERSION=0.8.3


### PR DESCRIPTION
- Changed `RSYNC_VERSION` from 3.4.1 to 3.4.2
- Updated download URL to point to the official GitHub release

This update includes improvements and bug fixes from the latest rsync release.

This also fixes a problem witht he other download place and that it that only the last version would be available in there so if we dont update on time, all of our builds will fails to obtains the previous rsync version