### PR TITLE
feat: Include RISC-V images in multi-arch manifests

### DIFF
--- a/.github/workflows/build-multiarch-images.yml
+++ b/.github/workflows/build-multiarch-images.yml
@@ -124,6 +124,7 @@ jobs:
     needs:
       - toolchain-amd64
       - toolchain-arm64
+      - toolchain-riscv64
     runs-on: ubuntu-24.04
     permissions:
       packages: write
@@ -150,6 +151,7 @@ jobs:
           sources: |
             ghcr.io/${{ github.repository }}-toolchain:${{ github.ref_name }}-amd64
             ghcr.io/${{ github.repository }}-toolchain:${{ github.ref_name }}-arm64
+            ghcr.io/${{ github.repository }}-toolchain:${{ github.ref_name }}-riscv64
       - uses: vlaurin/action-ghcr-prune@v0.6.0
         with:
           container: "${{ github.event.repository.name }}-toolchain"
@@ -161,6 +163,7 @@ jobs:
           prune-tags-regexes: |
             ^${{ github.ref_name }}-amd64$
             ^${{ github.ref_name }}-arm64$
+            ^${{ github.ref_name }}-riscv64$
   container-amd64:
     runs-on: oracle-vm-32cpu-128gb-x86-64
     needs:
@@ -276,6 +279,7 @@ jobs:
     needs:
       - container-amd64
       - container-arm64
+      - container-riscv64
     runs-on: ubuntu-24.04
     permissions:
       packages: write
@@ -302,6 +306,7 @@ jobs:
           sources: |
             ghcr.io/${{ github.repository }}-container:${{ github.ref_name }}-amd64
             ghcr.io/${{ github.repository }}-container:${{ github.ref_name }}-arm64
+            ghcr.io/${{ github.repository }}-container:${{ github.ref_name }}-riscv64
       - uses: vlaurin/action-ghcr-prune@v0.6.0
         with:
           container: "${{ github.event.repository.name }}-container"
@@ -313,6 +318,7 @@ jobs:
           prune-tags-regexes: |
             ^${{ github.ref_name }}-amd64$
             ^${{ github.ref_name }}-arm64$
+            ^${{ github.ref_name }}-riscv64$
   hadron-bios-amd64:
     runs-on: oracle-vm-32cpu-128gb-x86-64
     needs:
@@ -453,6 +459,7 @@ jobs:
     needs:
       - hadron-bios-amd64
       - hadron-bios-arm64
+      - hadron-bios-riscv64
     runs-on: ubuntu-24.04
     permissions:
       packages: write
@@ -486,6 +493,7 @@ jobs:
           sources: |
             ghcr.io/${{ github.repository }}${{ matrix.kernel == 'cloud' && '-cloud' || '' }}${{ matrix.fips == 'fips' && '-fips' || '' }}:${{ github.ref_name }}-amd64
             ghcr.io/${{ github.repository }}${{ matrix.kernel == 'cloud' && '-cloud' || '' }}${{ matrix.fips == 'fips' && '-fips' || '' }}:${{ github.ref_name }}-arm64
+            ${{ matrix.fips == 'no-fips' && format('ghcr.io/{0}{1}:{2}-riscv64', github.repository, matrix.kernel == 'cloud' && '-cloud' || '', github.ref_name) || '' }}
       - uses: vlaurin/action-ghcr-prune@v0.6.0
         with:
           container: "${{ github.event.repository.name }}${{ matrix.kernel == 'cloud' && '-cloud' || '' }}${{ matrix.fips == 'fips' && '-fips' || '' }}"
@@ -497,6 +505,7 @@ jobs:
           prune-tags-regexes: |
             ^${{ github.ref_name }}-amd64$
             ^${{ github.ref_name }}-arm64$
+            ^${{ github.ref_name }}-riscv64$
   hadron-trusted-amd64:
     runs-on: oracle-vm-32cpu-128gb-x86-64
     needs:
@@ -1195,12 +1204,12 @@ jobs:
             ARCH=riscv64
             BUILD_ARCH=riscv64
 
-  hadron-grub-riscv64:
+  hadron-bios-riscv64:
     runs-on: oracle-vm-32cpu-128gb-x86-64
     needs: [container-riscv64]
     strategy:
       matrix:
-        kernel: ["cloud"]
+        kernel: ["cloud", "default"]
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
## Summary
- Add riscv64 architecture to multi-arch container manifests (toolchain, container, hadron-bios)
- Build both cloud and default kernel variants for RISC-V (previously only cloud)
- Rename `hadron-grub-riscv64` to `hadron-bios-riscv64` for naming consistency
- Exclude riscv64 from FIPS variants (not supported on RISC-V)

This fixes errors like:
```
ERROR: failed to build: failed to solve: ghcr.io/kairos-io/hadron:v0.1.1: failed to resolve source metadata for ghcr.io/kairos-io/hadron:v0.1.1: no match for platform in manifest: not found
```

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] After merge, tag a release and confirm riscv64 appears in the multi-arch manifest
- [ ] Pull hadron image on a RISC-V system to confirm it resolves correctly

Made with [Cursor](https://cursor.com)