### PR TITLE
Dirtryfrag mitigation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3502,6 +3502,9 @@ RUN systemctl disable systemd-pcrlock-make-policy && systemctl mask systemd-pcrl
 # Add sysctl configs
 # TODO: kernel tuning based on the environment? Hardening? better defaults?
 COPY files/sysctl/* /etc/sysctl.d/
+# Add modprobe configs (currently only the dirtyfrag mitigation, see the file
+# for details). Remove the dirtyfrag.conf once the upstream kernel is patched.
+COPY files/modprobe.d/* /etc/modprobe.d/
 # copy a new login.defs to have better defaults as some stuff is already done by shadow and pam
 COPY files/login.defs /etc/login.defs
 ## Remove users stuff

--- a/files/modprobe.d/dirtyfrag.conf
+++ b/files/modprobe.d/dirtyfrag.conf
@@ -1,0 +1,9 @@
+# Mitigation for "dirtyfrag" (CVE-2026-43284, CVE-2026-43500).
+# See https://github.com/V4bel/dirtyfrag and
+# https://github.com/kairos-io/kairos/issues/4059.
+#
+# Disables the vulnerable esp4, esp6 and rxrpc modules until a kernel fix is
+# available. Remove this file once the upstream kernel has been patched.
+install esp4 /bin/false
+install esp6 /bin/false
+install rxrpc /bin/false


### PR DESCRIPTION
https://github.com/V4bel/dirtyfrag#mitigation

We can revert this when we bump to a kernel version that has this patched.

Fixes https://github.com/kairos-io/kairos/issues/4059