### PR TITLE
feat: Update Dracut version in Dockerfile and YAML

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -217,7 +217,7 @@ ARG KMOD_VERSION=34.2
 RUN wget -q https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-${KMOD_VERSION}.tar.gz -O kmod.tar.gz
 
 FROM sources-downloader-base AS dracut-download
-ARG DRACUT_VERSION=110
+ARG DRACUT_VERSION=111
 RUN wget -q https://github.com/dracut-ng/dracut-ng/archive/refs/tags/${DRACUT_VERSION}.tar.gz -O dracut.tar.gz
 
 FROM sources-downloader-base AS libaio-download

--- a/updatecli.d/kernel-and-boot.yaml
+++ b/updatecli.d/kernel-and-boot.yaml
@@ -41,8 +41,12 @@ sources:
     kind: gittag
     spec:
       url: git://git.kernel.org/pub/scm/linux/kernel/git/legion/kbd.git
+      versionfilter:
+        kind: semver
+        pattern: '*'
     transformers:
       - trimprefix: v
+
 
 targets:
   kernel:


### PR DESCRIPTION
- Changed `DRACUT_VERSION` from 110 to 111 in Dockerfile to use the latest features and fixes.
- Added a version filter in `kernel-and-boot.yaml` to ensure we dont tryt o update to kbd rc versions.

Release notes: https://github.com/dracut-ng/dracut/releases/tag/111