### PR TITLE
docs(examples): add Hetzner Cloud k3s + HCCM cloud-configs

### DIFF
--- a/examples/hetzner-cloud/README.md
+++ b/examples/hetzner-cloud/README.md
@@ -1,0 +1,149 @@
+# Hetzner Cloud — Kairos + k3s + Hetzner Cloud Controller Manager
+
+Ready-to-deploy [Kairos](https://kairos.io) cloud-configs for bootstrapping a single-node k3s cluster on [Hetzner Cloud](https://www.hetzner.com/cloud/) with the [Hetzner Cloud Controller Manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager) (HCCM / "hcloud CCM") pre-installed via [k3s auto-deploying manifests](https://docs.k3s.io/installation/packaged-components).
+
+Each variant produces a working cluster within ~1 min of first boot — no `kubectl apply` after install, no manual Helm runs.
+
+## Variants
+
+| File | What you get |
+|---|---|
+| **`hcm-only.yaml`** | k3s + Flannel (default CNI) + Hetzner CCM. No ingress controller. The minimum that exposes Hetzner Cloud Load Balancers and Volumes to your workloads. |
+| **`hcm-traefik.yaml`** | `hcm-only` + the k3s-bundled Traefik v3, reconfigured to enable its native [Gateway API](https://gateway-api.sigs.k8s.io/) provider. Lets you write `Gateway` + `HTTPRoute` resources out of the box. A Hetzner Cloud Load Balancer is auto-provisioned for Traefik. |
+| **`hcm-cilium.yaml`** | k3s with [Cilium](https://cilium.io/) as the CNI (eBPF dataplane, `kubeProxyReplacement: true`), in native-routing mode over the Hetzner private network. Hetzner CCM still runs (for node addressing + Hetzner LBs); Cilium handles all pod routing. Gateway API enabled via Cilium. |
+
+All three share the same plumbing:
+- HCCM via a `HelmChart` manifest dropped in `/var/lib/rancher/k3s/server/manifests/` at first boot
+- `networking.clusterCIDR: 10.42.0.0/16` so the CCM route-controller agrees with k3s's default pod CIDR (mismatch crashloops the CCM — see notes below)
+- A `stages.boot` step that detects the private-network IP and writes `node-ip:` to `/etc/rancher/k3s/config.yaml` *before* k3s starts (otherwise kubelet's TLS cert SAN omits the private IP, and `kubectl logs/exec/top` later fail with `x509` errors)
+
+## Repository layout
+
+```
+hetzner-cloud/
+├── README.md
+├── hcm-only.yaml          # cloud-config: HCCM + Flannel + hcloud-csi
+├── hcm-traefik.yaml       # cloud-config: + Traefik v3 Gateway API
+├── hcm-cilium.yaml        # cloud-config: + Cilium (replaces Flannel + kube-proxy)
+└── manifests/             # cleartext sources for every base64-encoded write_files entry
+    ├── hcloud-secret.yaml         # used by all three
+    ├── hcloud-ccm-only.yaml       # used by hcm-only
+    ├── hcloud-ccm-traefik.yaml    # used by hcm-traefik
+    ├── hcloud-ccm-cilium.yaml     # used by hcm-cilium
+    ├── hcloud-csi.yaml            # used by all three
+    ├── traefik-config.yaml        # used by hcm-traefik
+    ├── cilium.yaml                # used by hcm-cilium
+    └── regenerate-b64.sh          # re-encodes every manifest to single-line b64
+```
+
+The `manifests/` directory holds the cleartext source for every base64-encoded `write_files.content` field in the cloud-configs. The cloud-configs themselves still use the encoded form (cloud-init expects single-string `content`). If you change a manifest, run `bash manifests/regenerate-b64.sh` and paste the matching block into the `content:` field of the cloud-config(s) listed in the script's per-block `# consumed by:` header. The leading `#` explanation block at the top of each manifest file is stripped before encoding (it's there for human readers, not for k3s).
+
+## Prerequisites
+
+1. **A Hetzner Cloud account and project.** Free to create.
+2. **A custom Kairos ISO** uploaded to your Hetzner account. Hetzner does not allow direct ISO uploads — open a support ticket pointing at the Kairos ISO URL of your choice. See the [Kairos Hetzner installation guide](https://kairos.io/docs/installation/hetzner/) for the full flow.
+3. **A Hetzner Cloud API token** with **Read & Write** scope. Generate one in `Project → Security → API Tokens`.
+4. **A Hetzner Cloud Private Network** that your servers will be attached to. Without one the HCCM still runs but loses access to the per-node `InternalIP = private address` benefit (pod traffic stays on the public NIC).
+5. **A server name in Hetzner Cloud** that you use *exactly* in the cloud-config's `hostname:` field. The HCCM looks up each node by name in the Hetzner API; a mismatch breaks the node ↔ server binding (no `providerID`, no zone labels, possibly broken LB attachment). Pick a name in the Hetzner console first, then put the same name in the cloud-config.
+
+## Use
+
+1. **Pick the variant** that matches your needs (see table above).
+
+2. **Substitute the placeholders** in the file:
+
+   | Placeholder | Where | Replace with |
+   |---|---|---|
+   | `<YOUR_HETZNER_SERVER_NAME>` | `hostname:` line | The name you assigned to the Hetzner Cloud server in the console — **must match exactly** |
+   | `<K3S_TOKEN>` | `--token=...` in `k3s.args` | Any random string. The first node defines the cluster's shared secret; subsequent join nodes must use the same value. Example: `openssl rand -hex 32` |
+   | `<HETZNER_API_TOKEN>` and `<HETZNER_NETWORK_NAME_OR_ID>` | The `hcloud-secret.yaml` base64 content | Regenerate with: `printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: hcloud\n  namespace: kube-system\nstringData:\n  token: "<YOUR_TOKEN>"\n  network: "<YOUR_NETWORK>"\n' \| base64 -w0` — paste the output into the `content:` field |
+   | `"ssh-ed25519 AAAA... user@host"` | `users[0].ssh_authorized_keys` | Your public SSH key(s) |
+   | `<HETZNER_REGION>` (all three variants) | `HCLOUD_LOAD_BALANCERS_LOCATION` value inside the CCM `valuesContent` | One of `fsn1`, `nbg1`, `hel1`, `ash`, `hil`, `sin`. **Must align with your servers' Hetzner location** — the LB and servers have to share a Hetzner network zone (`eu-central` = fsn1/nbg1/hel1, `us-east` = ash, `us-west` = hil, `ap-southeast` = sin) for the bundled `HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP=true` setting to work. Best practice: set this to the **exact same** Hetzner location code as your servers. |
+
+3. **Paste the resulting cloud-config** into the [Kairos WebUI installer](https://kairos.io/docs/installation/webui/) when the VM boots from the Kairos ISO. The installer writes it to disk, then on first boot of the installed system everything provisions automatically.
+
+4. **Verify after first boot** (~1 min from kubelet-ready):
+   ```bash
+   kubectl get nodes -o wide
+   # Expect: STATUS Ready, INTERNAL-IP from your Hetzner private network (10.0.0.x by default)
+   kubectl -n kube-system get pods | grep hcloud-cloud-controller-manager
+   # Expect: 1/1 Running, RESTARTS=0
+   kubectl get node <hostname> -o jsonpath='{.spec.providerID}{"\n"}'
+   # Expect: hcloud://<numeric-server-id>  (proves CCM matched the Hetzner server)
+   ```
+
+## Security: restricting access to the LBs
+
+Hetzner Cloud Firewalls only apply to **servers**, not to Load Balancers — so you can't use one to filter who can reach an LB's public IP. Restrict at the LB itself instead.
+
+### 1. Allowlist source IPs on a public LB
+
+Set `loadBalancerSourceRanges` on the Service. HCCM translates it into the Hetzner LB's per-listener Source IP filter (visible in the Hetzner console under the service's "Source IPs"). Anything outside the listed CIDRs is dropped by the LB before it ever reaches your nodes.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-app
+spec:
+  type: LoadBalancer
+  loadBalancerSourceRanges:
+    - 203.0.113.42/32       # office IPv4
+    - 2a01:4f8::/29         # office IPv6
+  ports:
+    - { port: 443, targetPort: 8443 }
+```
+
+Caveats:
+- Applies to **all** listener ports of that Service. For per-port ACLs, configure the LB directly in the Hetzner console.
+- IPv4 and IPv6 CIDRs can mix in the same list. Empty list = wide open (the default).
+- For Cilium Gateway API (`hcm-cilium`) the Service is auto-created as `cilium-gateway-<gateway-name>` — `kubectl edit svc cilium-gateway-<name>` to add the field; Cilium preserves it on reconcile.
+- For Traefik (`hcm-traefik`) the Service is `traefik` in `kube-system` — edit it there.
+
+### 2. Make the LB private-only (no public IP)
+
+If a workload only needs to be reachable from other resources inside your Hetzner private network, give the LB no public IP at all. Skips public-side billing and removes the public attack surface entirely.
+
+```yaml
+metadata:
+  annotations:
+    load-balancer.hetzner.cloud/disable-public-network: "true"
+    load-balancer.hetzner.cloud/location: <HETZNER_REGION>
+    load-balancer.hetzner.cloud/network: <HETZNER_NETWORK_NAME_OR_ID>
+```
+
+The LB then has only a private IPv4 in your Hetzner network.
+
+### 3. Firewall the cluster nodes (defense in depth)
+
+Apply a Hetzner Cloud Firewall to the **server's public NIC** restricting inbound to only what you actually need from the Internet (e.g. SSH from trusted IPs, ICMP). All three variants bundle `HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP: "true"` in the CCM env, so the LB → node path rides the Hetzner private network — a tight public-NIC firewall will **not** mark LB targets Unhealthy. Without that flag you'd have to allowlist the Hetzner LB source ranges on the public NIC for health checks to pass — fragile and easy to get wrong.
+
+If you also want to restrict LB → node traffic itself, put the rules on the server's **private NIC** firewall (Hetzner Cloud Firewalls can be scoped per-NIC).
+
+## What can fail (and the fixes that are already baked in)
+
+The cloud-configs are the way they are because each of these failure modes was hit during validation. Knowing them helps debug if you change values:
+
+- **CCM crashloops with `ClusterCIDRMisconfigured`** → the chart default `networking.clusterCIDR` is `10.244.0.0/16` (vanilla k8s); k3s uses `10.42.0.0/16`. Already overridden in the CCM HelmChart values. **Do not change** unless you also change k3s's `--cluster-cidr`.
+- **`kubectl logs/exec/top` fails with `x509: certificate is valid for ..., not <private-ip>`** → kubelet generates its cert before the CCM moves InternalIP to the private network. The `stages.boot` step writes `node-ip` to k3s config *before* k3s starts, so kubelet includes the private IP in its cert SAN from the first registration.
+- **`Service type=LoadBalancer` stuck `<pending>`** → CCM doesn't know where to provision the Hetzner Cloud LB. All three variants set `HCLOUD_LOAD_BALANCERS_LOCATION` in CCM env (via the `<HETZNER_REGION>` placeholder). If you left the placeholder unsubstituted, the chart treats the literal string as an invalid location and the LB never provisions. Substitute it, or override per-Service with `load-balancer.hetzner.cloud/location: <region>`.
+- **LB Service has `EXTERNAL-IP` but the Hetzner console shows targets `Unhealthy`** → LB health checks dial the targets via their **public** IP by default, which a tight Hetzner Cloud Firewall on the server's public NIC (or public-NIC quirks like RPF / asymmetric routing) often silently drops. All three variants set `HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP: "true"` in CCM env so probes ride the private network instead, same path as inter-node traffic. Don't unset it unless you know what you're doing.
+- **Node has `<none>` InternalIP** → CCM didn't pick up `HCLOUD_NETWORK`. Confirm the `network:` field is present in the encoded secret AND `networking.enabled: true` is set in the CCM Helm values (`hcm-only.yaml` and `hcm-traefik.yaml`), or that `HCLOUD_NETWORK` is wired via the `env:` block in CCM values (`hcm-cilium.yaml`).
+- **`Node ... not found in Hetzner` events on the CCM** → `hostname:` doesn't match the Hetzner server name. Fix by aligning them.
+
+## Validation status
+
+| File | Validated end-to-end on Hetzner Cloud |
+|---|---|
+| `hcm-only.yaml` | ✅ single-node cpx32 in `fsn1`, attached to private network — Node Ready, CCM stable, kubelet TLS path healthy, `Service type=LoadBalancer` provisions a Hetzner LB, `hcloud-csi` provisions a Hetzner Cloud Volume |
+| `hcm-traefik.yaml` | ✅ same baseline as `hcm-only`, plus: Traefik Running, auto-generated `traefik-gateway` PROGRAMMED=True with Hetzner LB IP, `curl http://<lb-ip>/` flows Internet → LB → Traefik → HTTPRoute → backend pod (cross-namespace via `ReferenceGrant`), `hcloud-csi` PVC bound and read/write OK |
+| `hcm-cilium.yaml` | ✅ same baseline as `hcm-only`, plus: Cilium agent + operator Running (`cilium status` OK), `cilium` GatewayClass ACCEPTED=True, user-created Gateway PROGRAMMED with Hetzner LB IP, `curl http://<lb-ip>/` flows Internet → LB → Cilium Envoy → HTTPRoute → backend pod, `hcloud-csi` PVC bound and read/write OK |
+
+## Related
+
+- [Kairos Hetzner installation docs](https://kairos.io/docs/installation/hetzner/) — full install flow including custom-ISO request, server creation, WebUI install, and the underlying `write_files`/`stages.boot` patterns these examples build on
+- [Hetzner Cloud Controller Manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager) — upstream chart and CCM source
+- [HCCM official deployment docs](https://github.com/hetznercloud/hcloud-cloud-controller-manager/tree/main/docs) — authoritative reference for env vars, deploy modes (with / without networks), and Service annotations
+- [HCCM Helm chart values](https://github.com/hetznercloud/hcloud-cloud-controller-manager/tree/main/chart) — full list of supported `valuesContent` keys for the `HelmChart` manifest used here
+- [hcloud-csi-driver](https://github.com/hetznercloud/csi-driver) — Hetzner Cloud Volume CSI driver bundled by all three variants (`hcloud-volumes` StorageClass)
+- [Cilium k3s install guide](https://docs.cilium.io/en/stable/installation/k3s/) — generic Cilium-on-k3s reference (the `hcm-cilium.yaml` values are tuned for Hetzner private-network native routing on top of this)

--- a/examples/hetzner-cloud/hcm-cilium.yaml
+++ b/examples/hetzner-cloud/hcm-cilium.yaml
@@ -1,0 +1,126 @@
+#cloud-config
+
+# IMPORTANT: this hostname MUST match the server name you set in the Hetzner
+# Cloud console when creating the VM. The hcloud CCM identifies each node by
+# looking up the matching server in the Hetzner API by name first; a mismatch
+# leaves the CCM unable to identify the node and skips lifecycle reconciliation.
+hostname: <YOUR_HETZNER_SERVER_NAME>
+
+users:
+  - name: kairos
+    passwd: kairos
+    groups:
+      - admin
+    ssh_authorized_keys:
+      - "ssh-ed25519 AAAA... user@host"
+
+k3s:
+  enabled: true
+  args:
+    - --cluster-init
+    - --token=<K3S_TOKEN>
+    # Cloud-controller handoff (Hetzner CCM owns node addressing + LBs)
+    - --disable-cloud-controller          # let the Hetzner CCM run instead of k3s's built-in CCM
+    - --disable=traefik                   # don't install the bundled Traefik ingress
+    - --disable=servicelb                 # let the Hetzner CCM provision Hetzner Cloud Load Balancers for Service type=LoadBalancer
+    - --disable=local-storage             # don't install local-path-provisioner; hcloud-csi (below) becomes the sole (default) StorageClass — avoids two-defaults conflict
+    - --write-kubeconfig-mode=644         # /etc/rancher/k3s/k3s.yaml world-readable so kairos can kubectl without sudo
+    - --kubelet-arg=cloud-provider=external   # external CCM (Hetzner) owns node lifecycle
+    # CNI handoff (Cilium replaces everything below)
+    - --disable=kube-proxy                # Cilium runs in kubeProxyReplacement=true mode
+    - --flannel-backend=none              # don't install Flannel; Cilium is the CNI
+    - --disable-network-policy            # don't install the kube-router netpol controller; Cilium enforces policies
+    # Add --tls-san=<future-VIP-or-LB-IP-or-DNS> here on the very first --cluster-init boot
+    # if you plan to put a load balancer or VIP in front of the API server. Cannot be added later
+    # without re-issuing the server cert.
+
+# Detect the Hetzner private-network IP and tell k3s to use it as the node IP BEFORE
+# k3s starts. Prevents kubelet TLS SAN mismatch once the Hetzner CCM later sets
+# InternalIP to the private address (kubectl logs/exec via the API server fails
+# with x509 errors otherwise).
+stages:
+  boot:
+    - name: "detect hetzner private ip"
+      if: '[ ! -f /etc/rancher/k3s/config.yaml ]'
+      commands:
+        - mkdir -p /etc/rancher/k3s
+        - |
+          PRIVATE_IP=$(ip -4 -o addr show | awk '$4 ~ /^10\./ {print $4}' | cut -d/ -f1 | head -1)
+          [ -n "$PRIVATE_IP" ] && printf 'node-ip: %s\n' "$PRIVATE_IP" > /etc/rancher/k3s/config.yaml
+    # Fetch Gateway API CRDs (experimental channel: HTTPRoute + GRPCRoute + TLSRoute +
+    # BackendTLSPolicy that Cilium 1.18 actually uses) BEFORE k3s starts. The 00- prefix
+    # ensures k3s auto-deploy applies them first, so Cilium starts with Gateway API
+    # support already wired in (no post-boot kubectl, no Cilium pod restart).
+    - name: "fetch gateway api crds"
+      if: '[ ! -f /var/lib/rancher/k3s/server/manifests/00-gateway-api-crds.yaml ]'
+      commands:
+        - mkdir -p /var/lib/rancher/k3s/server/manifests
+        - curl -sSfL https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/experimental-install.yaml -o /var/lib/rancher/k3s/server/manifests/00-gateway-api-crds.yaml
+
+# k3s auto-applies any YAML found in /var/lib/rancher/k3s/server/manifests/ on first start.
+# Files dropped here BEFORE k3s starts therefore install at cluster bootstrap with no
+# manual kubectl.
+write_files:
+  # 1) Hetzner API token + private network name, as a Secret consumed by the CCM and
+  #    read by Cilium indirectly (via the node InternalIP that CCM populates with
+  #    HCLOUD_NETWORK).
+  #    DO NOT COMMIT this file with a real token — b64 is encoding, not encryption.
+  #    Regenerate with:
+  #      printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: hcloud\n  namespace: kube-system\nstringData:\n  token: "<TOKEN>"\n  network: "<NETWORK_NAME_OR_ID>"\n' | base64 -w0
+  - encoding: b64
+    path: /var/lib/rancher/k3s/server/manifests/hcloud-secret.yaml
+    permissions: "0600"
+    owner: "root"
+    content: YXBpVmVyc2lvbjogdjEKa2luZDogU2VjcmV0Cm1ldGFkYXRhOgogIG5hbWU6IGhjbG91ZAogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0Kc3RyaW5nRGF0YToKICB0b2tlbjogIjxIRVRaTkVSX0FQSV9UT0tFTj4iCiAgbmV0d29yazogIjxIRVRaTkVSX05FVFdPUktfTkFNRV9PUl9JRD4iCg==
+
+  # 2) HelmChart for the Hetzner cloud-controller-manager.
+  #    - networking.enabled: false — Cilium handles all pod networking; the CCM
+  #      only does node addressing + LB provisioning, no route management.
+  #    - env explicitly wires HCLOUD_NETWORK from the secret's `network` key so the
+  #      CCM sets each node's InternalIP to its Hetzner private-network IP. Without
+  #      this the chart only wires HCLOUD_TOKEN and InternalIP stays unset — Cilium
+  #      then falls back to the public IP for inter-node tunnels (slower, billed
+  #      traffic).
+  #    - env.HCLOUD_LOAD_BALANCERS_LOCATION: cluster-wide default Hetzner location
+  #      for Service type=LoadBalancer (including the one Cilium auto-creates for
+  #      a Gateway). Without it, every LB Service stays <pending>. MUST be aligned
+  #      with your servers' location — the LB and servers have to share a Hetzner
+  #      network zone (eu-central = fsn1/nbg1/hel1; us-east = ash; us-west = hil;
+  #      ap-southeast = sin) for USE_PRIVATE_IP below to work. Best practice: set
+  #      it to the exact same Hetzner location code as your servers.
+  #    - env.HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP: register every LB target by the
+  #      node's private IP (10.0.0.x) instead of public IP. Health checks then ride
+  #      the Hetzner private network. Without this, a tight Cloud Firewall on the
+  #      public NIC (or public-NIC quirks) silently drops probes and the LB shows
+  #      targets as Unhealthy even when real traffic flows. Strongly recommended.
+  - encoding: b64
+    path: /var/lib/rancher/k3s/server/manifests/hcloud-ccm.yaml
+    permissions: "0600"
+    owner: "root"
+    content: YXBpVmVyc2lvbjogaGVsbS5jYXR0bGUuaW8vdjEKa2luZDogSGVsbUNoYXJ0Cm1ldGFkYXRhOgogIG5hbWU6IGhjbG91ZC1jbG91ZC1jb250cm9sbGVyLW1hbmFnZXIKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCnNwZWM6CiAgY2hhcnQ6IGhjbG91ZC1jbG91ZC1jb250cm9sbGVyLW1hbmFnZXIKICByZXBvOiBodHRwczovL2NoYXJ0cy5oZXR6bmVyLmNsb3VkCiAgdGFyZ2V0TmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGJvb3RzdHJhcDogdHJ1ZQogIHZhbHVlc0NvbnRlbnQ6IHwtCiAgICBuZXR3b3JraW5nOgogICAgICBlbmFibGVkOiBmYWxzZQogICAgZW52OgogICAgICBIQ0xPVURfVE9LRU46CiAgICAgICAgdmFsdWVGcm9tOgogICAgICAgICAgc2VjcmV0S2V5UmVmOgogICAgICAgICAgICBuYW1lOiBoY2xvdWQKICAgICAgICAgICAga2V5OiB0b2tlbgogICAgICBIQ0xPVURfTkVUV09SSzoKICAgICAgICB2YWx1ZUZyb206CiAgICAgICAgICBzZWNyZXRLZXlSZWY6CiAgICAgICAgICAgIG5hbWU6IGhjbG91ZAogICAgICAgICAgICBrZXk6IG5ldHdvcmsKICAgICAgSENMT1VEX0xPQURfQkFMQU5DRVJTX0xPQ0FUSU9OOgogICAgICAgIHZhbHVlOiAiPEhFVFpORVJfUkVHSU9OPiIKICAgICAgSENMT1VEX0xPQURfQkFMQU5DRVJTX1VTRV9QUklWQVRFX0lQOgogICAgICAgIHZhbHVlOiAidHJ1ZSIK
+
+  # 3) HelmChart for Cilium 1.18.2 tuned for Hetzner + private network:
+  #    - kubeProxyReplacement: true — Cilium replaces kube-proxy fully
+  #    - routingMode: native + autoDirectNodeRoutes: true + ipv4NativeRoutingCIDR: 10.0.0.0/16
+  #      → pod-to-pod traffic between nodes goes direct over the Hetzner private network
+  #        (no VXLAN overhead, full MTU, free bandwidth)
+  #    - gatewayAPI.enabled: true (CRDs land via stages.boot above)
+  #    - l2announcements + externalIPs: false (Hetzner Cloud LB handles this)
+  - encoding: b64
+    path: /var/lib/rancher/k3s/server/manifests/cilium.yaml
+    permissions: "0600"
+    owner: "root"
+    content: YXBpVmVyc2lvbjogaGVsbS5jYXR0bGUuaW8vdjEKa2luZDogSGVsbUNoYXJ0Cm1ldGFkYXRhOgogIG5hbWU6IGNpbGl1bQogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0Kc3BlYzoKICBjaGFydDogY2lsaXVtCiAgcmVwbzogaHR0cHM6Ly9oZWxtLmNpbGl1bS5pby8KICB2ZXJzaW9uOiAxLjE4LjIKICB0YXJnZXROYW1lc3BhY2U6IGt1YmUtc3lzdGVtCiAgYm9vdHN0cmFwOiB0cnVlCiAgdmFsdWVzQ29udGVudDogfC0KICAgICMgZUJQRiByZXBsYWNlcyBrdWJlLXByb3h5IGVudGlyZWx5IChrM3Mgc3RhcnRlZCB3aXRoIC0tZGlzYWJsZS1rdWJlLXByb3h5KQogICAga3ViZVByb3h5UmVwbGFjZW1lbnQ6IHRydWUKICAgIGs4c1NlcnZpY2VIb3N0OiAxMjcuMC4wLjEKICAgIGs4c1NlcnZpY2VQb3J0OiA2NDQzCgogICAgIyBOYXRpdmUgcm91dGluZyBvdmVyIHRoZSBIZXR6bmVyIHByaXZhdGUgbmV0d29yayDigJQgbm8gVlhMQU4gZW5jYXAsIGZ1bGwKICAgICMgMTQ1MCBNVFUuIGF1dG9EaXJlY3ROb2RlUm91dGVzIGluc3RhbGxzIGRpcmVjdCByb3V0ZXMgYmV0d2VlbiBub2RlcwogICAgIyB1c2luZyBlYWNoIG5vZGUncyBJbnRlcm5hbElQLCB3aGljaCB0aGUgaGNsb3VkIENDTSBoYXMgc2V0IHRvIGl0cwogICAgIyBwcml2YXRlLW5ldHdvcmsgSVAgKGJlY2F1c2UgSENMT1VEX05FVFdPUksgaXMgd2lyZWQgaW4gaGNsb3VkLWNjbS55YW1sKS4KICAgICMgUG9kLXRvLXBvZCB0cmFmZmljIGJldHdlZW4gbm9kZXMgdGhlcmVmb3JlIHN0YXlzIG9uIHRoZSBIZXR6bmVyIHByaXZhdGUKICAgICMgbmV0d29yazogZnJlZSwgbG93LWxhdGVuY3ksIGhpZ2hlciBiYW5kd2lkdGggdGhhbiB0aGUgcHVibGljIE5JQy4KICAgIHJvdXRpbmdNb2RlOiBuYXRpdmUKICAgIGF1dG9EaXJlY3ROb2RlUm91dGVzOiB0cnVlCiAgICBpcHY0TmF0aXZlUm91dGluZ0NJRFI6IDEwLjAuMC4wLzE2ICAgICMgdGhlIEhldHpuZXIgcHJpdmF0ZS1uZXR3b3JrIHJhbmdlCgogICAgaXBhbToKICAgICAgbW9kZToga3ViZXJuZXRlcwogICAgb3BlcmF0b3I6CiAgICAgIHJlcGxpY2FzOiAxCgogICAgIyBIdWJibGUgZm9yIGZsb3cgb2JzZXJ2YWJpbGl0eSArIGBodWJibGUgb2JzZXJ2ZWAgZnJvbSBhbnkgbm9kZS4KICAgIGh1YmJsZToKICAgICAgZW5hYmxlZDogdHJ1ZQogICAgICByZWxheToKICAgICAgICBlbmFibGVkOiB0cnVlCiAgICAgIHVpOgogICAgICAgIGVuYWJsZWQ6IGZhbHNlCgogICAgIyBHYXRld2F5IEFQSSDigJQgaW1wbGVtZW50cyBnYXRld2F5Lm5ldHdvcmtpbmcuazhzLmlvLiBDUkRzIGFyZSBmZXRjaGVkCiAgICAjIHNlcGFyYXRlbHkgYXQgYm9vdCAoc2VlIHN0YWdlcy5ib290IGluIHRoZSBjbG91ZC1jb25maWcpLCBzbyB0aGV5IGV4aXN0CiAgICAjIGJlZm9yZSBDaWxpdW0gc3RhcnRzLgogICAgZ2F0ZXdheUFQSToKICAgICAgZW5hYmxlZDogdHJ1ZQogICAgICBlbmFibGVBbHBuOiB0cnVlICAgICAgICAgICAgICAjIEhUVFAvMiwgZ1JQQwogICAgICBlbmFibGVBcHBQcm90b2NvbDogdHJ1ZSAgICAgICAjIFNlcnZpY2Uuc3BlYy5wb3J0c1tdLmFwcFByb3RvY29sIHJvdXRpbmcKCiAgICAjIE9uIEhldHpuZXIgeW91IGhhdmUgcmVhbCBjbG91ZCBMQnMgdmlhIGhjbG91ZCBDQ00gKFNlcnZpY2UKICAgICMgdHlwZT1Mb2FkQmFsYW5jZXIg4oaSIEhldHpuZXIgQ2xvdWQgTG9hZCBCYWxhbmNlcikuIE5vIG5lZWQgZm9yIENpbGl1bSdzCiAgICAjIG9uLUxBTiBBUlAgLyBMMiBhbm5vdW5jZW1lbnQgbWFjaGluZXJ5IOKAlCBsZWF2ZSBpdCBvZmYgdG8gYXZvaWQKICAgICMgY29uZnVzaW5nIHRoZSBMQiBhbGxvY2F0aW9uIHBhdGguCiAgICBsMmFubm91bmNlbWVudHM6CiAgICAgIGVuYWJsZWQ6IGZhbHNlCiAgICBleHRlcm5hbElQczoKICAgICAgZW5hYmxlZDogZmFsc2UK
+
+  # 4) HelmChart for the Hetzner CSI driver. Reuses the same `hcloud` secret
+  #    (token + network) installed above. Registers a default StorageClass
+  #    `hcloud-volumes` (csi.hetzner.cloud provisioner) — any PVC without an
+  #    explicit storageClassName gets a Hetzner Cloud Volume, lazily created
+  #    when the first Pod consuming the PVC is scheduled (WaitForFirstConsumer).
+  #    Pairs with --disable=local-storage above so hcloud-volumes is the sole
+  #    default.
+  - encoding: b64
+    path: /var/lib/rancher/k3s/server/manifests/hcloud-csi.yaml
+    permissions: "0600"
+    owner: "root"
+    content: YXBpVmVyc2lvbjogaGVsbS5jYXR0bGUuaW8vdjEKa2luZDogSGVsbUNoYXJ0Cm1ldGFkYXRhOgogIG5hbWU6IGhjbG91ZC1jc2kKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCnNwZWM6CiAgY2hhcnQ6IGhjbG91ZC1jc2kKICByZXBvOiBodHRwczovL2NoYXJ0cy5oZXR6bmVyLmNsb3VkCiAgdGFyZ2V0TmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGJvb3RzdHJhcDogdHJ1ZQo=

--- a/examples/hetzner-cloud/hcm-only.yaml
+++ b/examples/hetzner-cloud/hcm-only.yaml
@@ -1,0 +1,121 @@
+#cloud-config
+
+# IMPORTANT: this hostname MUST match the server name you set in the Hetzner
+# Cloud console when creating the VM. The hcloud CCM identifies each node by
+# looking up the matching server in the Hetzner API by name first; a mismatch
+# leaves the CCM unable to identify the node and skips lifecycle reconciliation
+# (no providerID, no zone/region labels, possibly no Service-LoadBalancer
+# attachment). Either set this to a fixed value matching your Hetzner server
+# name, or rename the Hetzner server to match the templated output below.
+hostname: <YOUR_HETZNER_SERVER_NAME>
+
+users:
+  - name: kairos
+    passwd: kairos
+    groups:
+      - admin
+    ssh_authorized_keys:
+      - "ssh-ed25519 AAAA... user@host"
+
+k3s:
+  enabled: true
+  args:
+    - --cluster-init
+    - --token=<K3S_TOKEN>
+    - --disable-cloud-controller          # turn off k3s's built-in CCM so the Hetzner CCM can take over node addressing and load balancers
+    - --disable=traefik                   # don't install the bundled Traefik ingress; deploy your own ingress later if needed
+    - --disable=servicelb                 # don't install klipper-lb; the Hetzner CCM will provision Hetzner Cloud Load Balancers for Service type=LoadBalancer
+    - --disable=local-storage             # don't install local-path-provisioner; hcloud-csi (below) becomes the sole (default) StorageClass — avoids two-defaults conflict
+    - --write-kubeconfig-mode=644         # make /etc/rancher/k3s/k3s.yaml world-readable so the kairos user can run kubectl without sudo
+    - --kubelet-arg=cloud-provider=external   # tell kubelet that an external cloud provider (Hetzner CCM) is responsible for node initialization and lifecycle
+    # Add --tls-san=<future-VIP-or-LB-IP-or-DNS> here on the very first --cluster-init boot
+    # if you plan to put a load balancer or VIP in front of the API server. Cannot be added later
+    # without re-issuing the server cert.
+
+# Detect the Hetzner private-network IP and tell k3s to use it as the node IP
+# BEFORE k3s starts. Without this, kubelet's TLS cert SAN only includes the
+# public IP, and once the Hetzner CCM later sets InternalIP to the private
+# address, every API → kubelet path (kubectl logs / exec / top, metrics-server)
+# fails with:
+#     x509: certificate is valid for ..., not <private-ip>
+# k3s reads /etc/rancher/k3s/config.yaml at start; setting `node-ip` there is
+# equivalent to passing --node-ip and makes kubelet include the IP in its cert
+# SAN from the very first registration.
+stages:
+  boot:
+    - name: "detect hetzner private ip"
+      if: '[ ! -f /etc/rancher/k3s/config.yaml ]'
+      commands:
+        - mkdir -p /etc/rancher/k3s
+        - |
+          # Pick the first IPv4 in the 10.0.0.0/8 range (Hetzner private network).
+          # Adjust the regex if you use a different private CIDR.
+          PRIVATE_IP=$(ip -4 -o addr show | awk '$4 ~ /^10\./ {print $4}' | cut -d/ -f1 | head -1)
+          [ -n "$PRIVATE_IP" ] && printf 'node-ip: %s\n' "$PRIVATE_IP" > /etc/rancher/k3s/config.yaml
+
+# k3s auto-applies any YAML found in /var/lib/rancher/k3s/server/manifests/ on first start.
+# Files dropped here BEFORE k3s starts therefore install at cluster bootstrap with no manual kubectl.
+write_files:
+  # 1) The Hetzner API token + private network name, as a Secret consumed by the CCM.
+  #    DO NOT COMMIT this file with a real token — b64 is encoding, not encryption.
+  #    Regenerate with your real values:
+  #      printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: hcloud\n  namespace: kube-system\nstringData:\n  token: "<TOKEN>"\n  network: "<NETWORK_NAME_OR_ID>"\n' | base64 -w0
+  - encoding: b64
+    path: /var/lib/rancher/k3s/server/manifests/hcloud-secret.yaml
+    permissions: "0600"
+    owner: "root"
+    content: YXBpVmVyc2lvbjogdjEKa2luZDogU2VjcmV0Cm1ldGFkYXRhOgogIG5hbWU6IGhjbG91ZAogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0Kc3RyaW5nRGF0YToKICB0b2tlbjogIjxIRVRaTkVSX0FQSV9UT0tFTj4iCiAgbmV0d29yazogIjxIRVRaTkVSX05FVFdPUktfTkFNRV9PUl9JRD4iCg==
+
+  # 2) HelmChart for the Hetzner cloud-controller-manager.
+  #    networking.enabled: true is the simplest and most beginner-friendly form:
+  #    - chart auto-wires HCLOUD_TOKEN and HCLOUD_NETWORK from the `hcloud` secret
+  #    - CCM sets each node's InternalIP to its Hetzner private-network IP (10.0.0.x)
+  #    - CCM also runs a route-controller that adds routes for the pod CIDR through
+  #      the Hetzner private network
+  #
+  #    networking.clusterCIDR MUST match the k3s pod CIDR (k3s default = 10.42.0.0/16).
+  #    The chart's default of 10.244.0.0/16 (vanilla k8s) does NOT match k3s, so the
+  #    route-controller crashloops with ClusterCIDRMisconfigured. Always set this
+  #    when enabling networking on k3s.
+  #
+  #    On a single node the route-controller is harmless (no peers to route to).
+  #    On multi-node with another overlay CNI, the route-controller can collide with the
+  #    CNI's own routes for the pod CIDR. If you hit that, switch to:
+  #        networking:
+  #          enabled: false
+  #        env:
+  #          HCLOUD_TOKEN: {valueFrom: {secretKeyRef: {name: hcloud, key: token}}}
+  #          HCLOUD_NETWORK: {valueFrom: {secretKeyRef: {name: hcloud, key: network}}}
+  #    which gets you private-network addressing without route management.
+  #
+  #    env.HCLOUD_LOAD_BALANCERS_LOCATION: cluster-wide default Hetzner location for
+  #    Service type=LoadBalancer. Without it, every LB Service stays <pending>
+  #    ("neither location nor network-zone set"). MUST be aligned with your servers'
+  #    location — the LB and servers have to share a Hetzner network zone (eu-central
+  #    = fsn1/nbg1/hel1; us-east = ash; us-west = hil; ap-southeast = sin) for the
+  #    USE_PRIVATE_IP path below to work. Best practice: set it to the exact same
+  #    Hetzner location code as your servers.
+  #
+  #    env.HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP: register every LB target by the
+  #    node's private IP (10.0.0.x) instead of public IP. Health checks then ride
+  #    the Hetzner private network. Without this, a tight Hetzner Cloud Firewall on
+  #    the public NIC (or public-NIC quirks like RPF / asymmetric routing) silently
+  #    drops the probes and the LB shows targets as Unhealthy even when real traffic
+  #    is flowing. Strongly recommended.
+  - encoding: b64
+    path: /var/lib/rancher/k3s/server/manifests/hcloud-ccm.yaml
+    permissions: "0600"
+    owner: "root"
+    content: YXBpVmVyc2lvbjogaGVsbS5jYXR0bGUuaW8vdjEKa2luZDogSGVsbUNoYXJ0Cm1ldGFkYXRhOgogIG5hbWU6IGhjbG91ZC1jbG91ZC1jb250cm9sbGVyLW1hbmFnZXIKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCnNwZWM6CiAgY2hhcnQ6IGhjbG91ZC1jbG91ZC1jb250cm9sbGVyLW1hbmFnZXIKICByZXBvOiBodHRwczovL2NoYXJ0cy5oZXR6bmVyLmNsb3VkCiAgdGFyZ2V0TmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGJvb3RzdHJhcDogdHJ1ZQogIHZhbHVlc0NvbnRlbnQ6IHwtCiAgICBuZXR3b3JraW5nOgogICAgICBlbmFibGVkOiB0cnVlCiAgICAgIGNsdXN0ZXJDSURSOiAxMC40Mi4wLjAvMTYKICAgIGVudjoKICAgICAgSENMT1VEX0xPQURfQkFMQU5DRVJTX0xPQ0FUSU9OOgogICAgICAgIHZhbHVlOiAiPEhFVFpORVJfUkVHSU9OPiIKICAgICAgSENMT1VEX0xPQURfQkFMQU5DRVJTX1VTRV9QUklWQVRFX0lQOgogICAgICAgIHZhbHVlOiAidHJ1ZSIK
+
+  # 3) HelmChart for the Hetzner CSI driver. Reuses the same `hcloud` secret
+  #    (token + network) installed above. Once running, it registers a default
+  #    StorageClass `hcloud-volumes` (csi.hetzner.cloud provisioner), so any PVC
+  #    that does not specify storageClassName gets a Hetzner Cloud Volume.
+  #    Volume creation is lazy (WaitForFirstConsumer) — the actual Hetzner
+  #    Volume is created when the first Pod consuming the PVC is scheduled.
+  - encoding: b64
+    path: /var/lib/rancher/k3s/server/manifests/hcloud-csi.yaml
+    permissions: "0600"
+    owner: "root"
+    content: YXBpVmVyc2lvbjogaGVsbS5jYXR0bGUuaW8vdjEKa2luZDogSGVsbUNoYXJ0Cm1ldGFkYXRhOgogIG5hbWU6IGhjbG91ZC1jc2kKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCnNwZWM6CiAgY2hhcnQ6IGhjbG91ZC1jc2kKICByZXBvOiBodHRwczovL2NoYXJ0cy5oZXR6bmVyLmNsb3VkCiAgdGFyZ2V0TmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGJvb3RzdHJhcDogdHJ1ZQo=

--- a/examples/hetzner-cloud/hcm-traefik.yaml
+++ b/examples/hetzner-cloud/hcm-traefik.yaml
@@ -1,0 +1,122 @@
+#cloud-config
+
+# IMPORTANT: this hostname MUST match the server name you set in the Hetzner
+# Cloud console when creating the VM. The hcloud CCM identifies each node by
+# looking up the matching server in the Hetzner API by name first; a mismatch
+# leaves the CCM unable to identify the node and skips lifecycle reconciliation.
+hostname: <YOUR_HETZNER_SERVER_NAME>
+
+users:
+  - name: kairos
+    passwd: kairos
+    groups:
+      - admin
+    ssh_authorized_keys:
+      - "ssh-ed25519 AAAA... user@host"
+
+k3s:
+  enabled: true
+  args:
+    - --cluster-init
+    - --token=<K3S_TOKEN>
+    # Cloud-controller handoff: Hetzner CCM owns node addressing + LB provisioning
+    - --disable-cloud-controller          # k3s's built-in CCM is replaced by hcloud CCM
+    - --disable=servicelb                 # let hcloud CCM provision Hetzner Cloud LBs for Service type=LoadBalancer (including Traefik's)
+    - --disable=local-storage             # don't install local-path-provisioner; hcloud-csi (below) becomes the sole (default) StorageClass — avoids two-defaults conflict
+    - --write-kubeconfig-mode=644         # /etc/rancher/k3s/k3s.yaml world-readable so kairos can kubectl without sudo
+    - --kubelet-arg=cloud-provider=external   # external CCM (Hetzner) owns node lifecycle
+    # NOTE: --disable=traefik is *omitted* on purpose. k3s 1.32+ bundles Traefik v3,
+    # which has a native Gateway API provider — we enable it via HelmChartConfig below.
+    # Traefik becomes the L7 ingress for the cluster, exposed publicly via a Hetzner
+    # Cloud Load Balancer (provisioned automatically by the Hetzner CCM).
+    # ⚠ This auto-creates a Hetzner Cloud LB the moment Traefik comes up (~€5.83/mo
+    # for LB11). If you don't want that, add `- --disable=traefik` here and skip the
+    # traefik-config.yaml write_files entry below.
+    #
+    # Add --tls-san=<future-VIP-or-LB-IP-or-DNS> here on the very first --cluster-init
+    # boot if you plan to put a load balancer in front of the API server; cannot be
+    # added later without re-issuing the server cert.
+
+# Detect the Hetzner private-network IP and tell k3s to use it as the node IP
+# BEFORE k3s starts. Prevents kubelet TLS SAN mismatch once the Hetzner CCM
+# later sets InternalIP to the private address (otherwise kubectl logs/exec
+# via the API server fails with x509 errors).
+#
+# NOTE: we do NOT pre-fetch Gateway API CRDs here, unlike the hcm-cilium variant.
+# The k3s 1.32+ bundled traefik-crd HelmChart installs the Gateway API CRDs
+# itself (Traefik v3 needs them for its kubernetesGateway provider). Pre-applying
+# CRDs that lack Helm ownership labels makes `helm install traefik-crd` fail
+# with "invalid ownership metadata; ... missing key app.kubernetes.io/managed-by".
+stages:
+  boot:
+    - name: "detect hetzner private ip"
+      if: '[ ! -f /etc/rancher/k3s/config.yaml ]'
+      commands:
+        - mkdir -p /etc/rancher/k3s
+        - |
+          PRIVATE_IP=$(ip -4 -o addr show | awk '$4 ~ /^10\./ {print $4}' | cut -d/ -f1 | head -1)
+          [ -n "$PRIVATE_IP" ] && printf 'node-ip: %s\n' "$PRIVATE_IP" > /etc/rancher/k3s/config.yaml
+
+# k3s auto-applies any YAML found in /var/lib/rancher/k3s/server/manifests/ on first
+# start. Files dropped here before k3s starts therefore install at cluster bootstrap
+# with no manual kubectl.
+write_files:
+  # 1) Hetzner API token + private network name, consumed by the CCM.
+  #    DO NOT COMMIT with a real token — b64 is encoding, not encryption.
+  #    Regenerate with:
+  #      printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: hcloud\n  namespace: kube-system\nstringData:\n  token: "<TOKEN>"\n  network: "<NETWORK_NAME_OR_ID>"\n' | base64 -w0
+  - encoding: b64
+    path: /var/lib/rancher/k3s/server/manifests/hcloud-secret.yaml
+    permissions: "0600"
+    owner: "root"
+    content: YXBpVmVyc2lvbjogdjEKa2luZDogU2VjcmV0Cm1ldGFkYXRhOgogIG5hbWU6IGhjbG91ZAogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0Kc3RyaW5nRGF0YToKICB0b2tlbjogIjxIRVRaTkVSX0FQSV9UT0tFTj4iCiAgbmV0d29yazogIjxIRVRaTkVSX05FVFdPUktfTkFNRV9PUl9JRD4iCg==
+
+  # 2) HelmChart for the Hetzner cloud-controller-manager.
+  #    - networking.enabled: true auto-wires HCLOUD_TOKEN + HCLOUD_NETWORK from
+  #      the secret.
+  #    - networking.clusterCIDR MUST be set to k3s's pod CIDR (10.42.0.0/16) —
+  #      the chart default is 10.244.0.0/16 (vanilla k8s), which mismatches k3s
+  #      and crashloops the route-controller.
+  #    - env.HCLOUD_LOAD_BALANCERS_LOCATION: cluster-wide default Hetzner
+  #      location for Service type=LoadBalancer. Without it, every LB Service
+  #      stays <pending> ("neither location nor network-zone set"). Replace
+  #      <HETZNER_REGION> with the Hetzner location of your servers (one of:
+  #      fsn1, nbg1, hel1, ash, hil, sin).
+  #    - env.HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP: register every LB target by
+  #      the node's private IP (10.0.0.x) instead of public IP. Health checks
+  #      then ride the Hetzner private network — without this, Hetzner Cloud
+  #      Firewall (or just public-NIC quirks) often drops the probes and the
+  #      LB shows targets as Unhealthy even when traffic is flowing.
+  - encoding: b64
+    path: /var/lib/rancher/k3s/server/manifests/hcloud-ccm.yaml
+    permissions: "0600"
+    owner: "root"
+    content: YXBpVmVyc2lvbjogaGVsbS5jYXR0bGUuaW8vdjEKa2luZDogSGVsbUNoYXJ0Cm1ldGFkYXRhOgogIG5hbWU6IGhjbG91ZC1jbG91ZC1jb250cm9sbGVyLW1hbmFnZXIKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCnNwZWM6CiAgY2hhcnQ6IGhjbG91ZC1jbG91ZC1jb250cm9sbGVyLW1hbmFnZXIKICByZXBvOiBodHRwczovL2NoYXJ0cy5oZXR6bmVyLmNsb3VkCiAgdGFyZ2V0TmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGJvb3RzdHJhcDogdHJ1ZQogIHZhbHVlc0NvbnRlbnQ6IHwtCiAgICBuZXR3b3JraW5nOgogICAgICBlbmFibGVkOiB0cnVlCiAgICAgIGNsdXN0ZXJDSURSOiAxMC40Mi4wLjAvMTYKICAgIGVudjoKICAgICAgSENMT1VEX0xPQURfQkFMQU5DRVJTX0xPQ0FUSU9OOgogICAgICAgIHZhbHVlOiAiPEhFVFpORVJfUkVHSU9OPiIKICAgICAgSENMT1VEX0xPQURfQkFMQU5DRVJTX1VTRV9QUklWQVRFX0lQOgogICAgICAgIHZhbHVlOiAidHJ1ZSIK
+
+  # 3) HelmChartConfig that overrides the bundled k3s Traefik chart's values
+  #    to turn on Traefik v3's native Gateway API provider.
+  #    The chart then AUTO-CREATES a Gateway resource on Traefik's internal
+  #    entrypoint ports (web=8000, websecure=8443) — the Hetzner Cloud LB in
+  #    front of the Service exposes those externally on ports 80/443.
+  #    Attach your HTTPRoute via `parentRefs: [{name: traefik, namespace: kube-system}]`;
+  #    you do NOT need to create your own Gateway. If you DO write your own
+  #    Gateway, its listeners[0].port must be 8000 or 8443 (NOT 80/443) — the
+  #    chart's gateway.yaml template hardcodes the internal entrypoint ports.
+  - encoding: b64
+    path: /var/lib/rancher/k3s/server/manifests/traefik-config.yaml
+    permissions: "0600"
+    owner: "root"
+    content: YXBpVmVyc2lvbjogaGVsbS5jYXR0bGUuaW8vdjEKa2luZDogSGVsbUNoYXJ0Q29uZmlnCm1ldGFkYXRhOgogIG5hbWU6IHRyYWVmaWsKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCnNwZWM6CiAgdmFsdWVzQ29udGVudDogfC0KICAgIHByb3ZpZGVyczoKICAgICAga3ViZXJuZXRlc0dhdGV3YXk6CiAgICAgICAgZW5hYmxlZDogdHJ1ZQo=
+
+  # 4) HelmChart for the Hetzner CSI driver. Reuses the same `hcloud` secret
+  #    (token + network) installed above. Registers a default StorageClass
+  #    `hcloud-volumes` (csi.hetzner.cloud provisioner) — any PVC without an
+  #    explicit storageClassName gets a Hetzner Cloud Volume, lazily created
+  #    when the first Pod consuming the PVC is scheduled (WaitForFirstConsumer).
+  #    Pairs with --disable=local-storage above so hcloud-volumes is the sole
+  #    default and PVCs don't have to pick between two defaults.
+  - encoding: b64
+    path: /var/lib/rancher/k3s/server/manifests/hcloud-csi.yaml
+    permissions: "0600"
+    owner: "root"
+    content: YXBpVmVyc2lvbjogaGVsbS5jYXR0bGUuaW8vdjEKa2luZDogSGVsbUNoYXJ0Cm1ldGFkYXRhOgogIG5hbWU6IGhjbG91ZC1jc2kKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCnNwZWM6CiAgY2hhcnQ6IGhjbG91ZC1jc2kKICByZXBvOiBodHRwczovL2NoYXJ0cy5oZXR6bmVyLmNsb3VkCiAgdGFyZ2V0TmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGJvb3RzdHJhcDogdHJ1ZQo=

--- a/examples/hetzner-cloud/manifests/cilium.yaml
+++ b/examples/hetzner-cloud/manifests/cilium.yaml
@@ -1,0 +1,59 @@
+# Used by hcm-cilium.yaml. Cilium 1.18.2 tuned for Hetzner + private network.
+# Gateway API CRDs are fetched separately at boot (see stages.boot in the
+# cloud-config), so they exist before Cilium starts.
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  chart: cilium
+  repo: https://helm.cilium.io/
+  version: 1.18.2
+  targetNamespace: kube-system
+  bootstrap: true
+  valuesContent: |-
+    # eBPF replaces kube-proxy entirely (k3s started with --disable-kube-proxy)
+    kubeProxyReplacement: true
+    k8sServiceHost: 127.0.0.1
+    k8sServicePort: 6443
+
+    # Native routing over the Hetzner private network — no VXLAN encap, full
+    # 1450 MTU. autoDirectNodeRoutes installs direct routes between nodes
+    # using each node's InternalIP, which the hcloud CCM has set to its
+    # private-network IP (because HCLOUD_NETWORK is wired in hcloud-ccm.yaml).
+    # Pod-to-pod traffic between nodes therefore stays on the Hetzner private
+    # network: free, low-latency, higher bandwidth than the public NIC.
+    routingMode: native
+    autoDirectNodeRoutes: true
+    ipv4NativeRoutingCIDR: 10.0.0.0/16    # the Hetzner private-network range
+
+    ipam:
+      mode: kubernetes
+    operator:
+      replicas: 1
+
+    # Hubble for flow observability + `hubble observe` from any node.
+    hubble:
+      enabled: true
+      relay:
+        enabled: true
+      ui:
+        enabled: false
+
+    # Gateway API — implements gateway.networking.k8s.io. CRDs are fetched
+    # separately at boot (see stages.boot in the cloud-config), so they exist
+    # before Cilium starts.
+    gatewayAPI:
+      enabled: true
+      enableAlpn: true              # HTTP/2, gRPC
+      enableAppProtocol: true       # Service.spec.ports[].appProtocol routing
+
+    # On Hetzner you have real cloud LBs via hcloud CCM (Service
+    # type=LoadBalancer → Hetzner Cloud Load Balancer). No need for Cilium's
+    # on-LAN ARP / L2 announcement machinery — leave it off to avoid
+    # confusing the LB allocation path.
+    l2announcements:
+      enabled: false
+    externalIPs:
+      enabled: false

--- a/examples/hetzner-cloud/manifests/hcloud-ccm-cilium.yaml
+++ b/examples/hetzner-cloud/manifests/hcloud-ccm-cilium.yaml
@@ -1,0 +1,39 @@
+# Used by hcm-cilium.yaml.
+# networking.enabled: false — Cilium owns pod routing (native routing over the
+# Hetzner private network); the CCM only does node addressing + LB provisioning,
+# no route management. Setting it true would have CCM install routes that
+# collide with Cilium's autoDirectNodeRoutes.
+#
+# env explicitly wires HCLOUD_TOKEN + HCLOUD_NETWORK from the secret. With
+# networking.enabled=false the chart no longer auto-wires HCLOUD_NETWORK, so
+# without this block the CCM doesn't know which Hetzner network to look at
+# and InternalIP stays unset on every Node (Cilium then falls back to the
+# public IP for inter-node traffic — slower, billed).
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: hcloud-cloud-controller-manager
+  namespace: kube-system
+spec:
+  chart: hcloud-cloud-controller-manager
+  repo: https://charts.hetzner.cloud
+  targetNamespace: kube-system
+  bootstrap: true
+  valuesContent: |-
+    networking:
+      enabled: false
+    env:
+      HCLOUD_TOKEN:
+        valueFrom:
+          secretKeyRef:
+            name: hcloud
+            key: token
+      HCLOUD_NETWORK:
+        valueFrom:
+          secretKeyRef:
+            name: hcloud
+            key: network
+      HCLOUD_LOAD_BALANCERS_LOCATION:
+        value: "<HETZNER_REGION>"
+      HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP:
+        value: "true"

--- a/examples/hetzner-cloud/manifests/hcloud-ccm-only.yaml
+++ b/examples/hetzner-cloud/manifests/hcloud-ccm-only.yaml
@@ -1,0 +1,27 @@
+# Used by hcm-only.yaml.
+# networking.enabled: true → CCM manages pod-CIDR routes through the Hetzner
+# private network (works because hcm-only uses Flannel, which doesn't install
+# its own routes). On hcm-cilium we flip this to false because Cilium owns
+# routing.
+# clusterCIDR MUST match k3s's pod CIDR (default 10.42.0.0/16). The chart
+# default (10.244.0.0/16) is vanilla k8s — using it on k3s crashloops the
+# route-controller with ClusterCIDRMisconfigured.
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: hcloud-cloud-controller-manager
+  namespace: kube-system
+spec:
+  chart: hcloud-cloud-controller-manager
+  repo: https://charts.hetzner.cloud
+  targetNamespace: kube-system
+  bootstrap: true
+  valuesContent: |-
+    networking:
+      enabled: true
+      clusterCIDR: 10.42.0.0/16
+    env:
+      HCLOUD_LOAD_BALANCERS_LOCATION:
+        value: "<HETZNER_REGION>"
+      HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP:
+        value: "true"

--- a/examples/hetzner-cloud/manifests/hcloud-ccm-traefik.yaml
+++ b/examples/hetzner-cloud/manifests/hcloud-ccm-traefik.yaml
@@ -1,0 +1,24 @@
+# Used by hcm-traefik.yaml.
+# Identical to hcloud-ccm-only.yaml today (Flannel + CCM-managed routes); kept
+# as a separate file so each cloud-config has a 1:1 cleartext source. If you
+# tweak Traefik-specific CCM behavior in the future (e.g. different LB env),
+# diverge here without touching hcm-only.
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: hcloud-cloud-controller-manager
+  namespace: kube-system
+spec:
+  chart: hcloud-cloud-controller-manager
+  repo: https://charts.hetzner.cloud
+  targetNamespace: kube-system
+  bootstrap: true
+  valuesContent: |-
+    networking:
+      enabled: true
+      clusterCIDR: 10.42.0.0/16
+    env:
+      HCLOUD_LOAD_BALANCERS_LOCATION:
+        value: "<HETZNER_REGION>"
+      HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP:
+        value: "true"

--- a/examples/hetzner-cloud/manifests/hcloud-csi.yaml
+++ b/examples/hetzner-cloud/manifests/hcloud-csi.yaml
@@ -1,0 +1,16 @@
+# Shared by all three cloud-configs. Reuses the hcloud Secret installed above.
+# Registers a default StorageClass `hcloud-volumes` (csi.hetzner.cloud
+# provisioner) — any PVC without an explicit storageClassName gets a Hetzner
+# Cloud Volume, lazily created when the first Pod consuming the PVC is
+# scheduled (WaitForFirstConsumer). Pairs with k3s's --disable=local-storage
+# so hcloud-volumes is the sole default StorageClass.
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: hcloud-csi
+  namespace: kube-system
+spec:
+  chart: hcloud-csi
+  repo: https://charts.hetzner.cloud
+  targetNamespace: kube-system
+  bootstrap: true

--- a/examples/hetzner-cloud/manifests/hcloud-secret.yaml
+++ b/examples/hetzner-cloud/manifests/hcloud-secret.yaml
@@ -1,0 +1,11 @@
+# Shared by all three cloud-configs (hcm-only, hcm-traefik, hcm-cilium).
+# Consumed by the Hetzner CCM and the hcloud-csi driver.
+# Placeholders MUST be substituted before encoding — see README.md.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hcloud
+  namespace: kube-system
+stringData:
+  token: "<HETZNER_API_TOKEN>"
+  network: "<HETZNER_NETWORK_NAME_OR_ID>"

--- a/examples/hetzner-cloud/manifests/regenerate-b64.sh
+++ b/examples/hetzner-cloud/manifests/regenerate-b64.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Encode each cleartext manifest to single-line base64 and print it.
+# Paste the output into the matching `content:` field in the cloud-config(s)
+# listed in the header above each block.
+#
+# Leading file-explanation comments (the block of `#` lines at the top of
+# each manifest, before the first YAML node) are STRIPPED before encoding.
+# They exist to help humans browsing manifests/ — they don't need to be
+# embedded in the cloud-config's encoded `content:` field, which only
+# Kubernetes ever sees. Inline comments inside `valuesContent:` blocks are
+# preserved (they're part of the chart values payload).
+#
+# Usage (from anywhere): bash examples/hetzner-cloud/manifests/regenerate-b64.sh
+#
+# Dependencies: bash, awk, base64 (all in POSIX coreutils on Linux/macOS).
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+emit() {
+  local file="$1"; shift
+  echo
+  echo "=== ${file} ==="
+  echo "# consumed by: $*"
+  awk '!started && (/^#/ || /^[[:space:]]*$/) {next} {started=1; print}' "${DIR}/${file}" \
+    | base64 | tr -d '\n'
+  echo
+}
+
+emit hcloud-secret.yaml       hcm-only.yaml  hcm-traefik.yaml  hcm-cilium.yaml
+emit hcloud-ccm-only.yaml     hcm-only.yaml
+emit hcloud-ccm-traefik.yaml  hcm-traefik.yaml
+emit hcloud-ccm-cilium.yaml   hcm-cilium.yaml
+emit traefik-config.yaml      hcm-traefik.yaml
+emit cilium.yaml              hcm-cilium.yaml
+emit hcloud-csi.yaml          hcm-only.yaml  hcm-traefik.yaml  hcm-cilium.yaml

--- a/examples/hetzner-cloud/manifests/traefik-config.yaml
+++ b/examples/hetzner-cloud/manifests/traefik-config.yaml
@@ -1,0 +1,27 @@
+# Used by hcm-traefik.yaml. Overrides the k3s-bundled Traefik chart values
+# to enable Traefik v3's native Gateway API provider. The bundled chart then
+# AUTO-CREATES a Gateway resource on Traefik's internal entrypoint ports
+# (web=8000, websecure=8443), which the Hetzner Cloud LB in front of the
+# Service exposes externally on ports 80/443.
+#
+# Attach your HTTPRoute / GRPCRoute / TLSRoute to that auto-generated
+# Gateway via parentRefs (default name "traefik", in kube-system) — you do
+# NOT need to write your own Gateway resource. NOTE: the auto-generated
+# Gateway's listener uses `allowedRoutes.namespaces.from: Same`, so the
+# HTTPRoute must live in kube-system. To target a backend in another
+# namespace, add a ReferenceGrant in the backend's namespace.
+#
+# If you DO write your own Gateway, its listeners[0].port must be 8000
+# (HTTP) or 8443 (HTTPS) to match Traefik's internal entrypoints — NOT
+# 80/443. Overriding `ports.web.port: 80` breaks the bundled chart's
+# gateway.yaml template ("port 8000 is not declared in ports").
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    providers:
+      kubernetesGateway:
+        enabled: true


### PR DESCRIPTION
Three ready-to-deploy Kairos cloud-configs for single-node k3s on Hetzner Cloud, with the Hetzner Cloud Controller Manager and Cloud Volume CSI driver pre-installed via k3s auto-deploy manifests. Working cluster in ~1 min from first boot — no \`kubectl apply\`, no manual Helm runs.

| File | What you get |
|---|---|
| \`hcm-only.yaml\` | HCCM + Flannel + hcloud-csi |
| \`hcm-traefik.yaml\` | + k3s-bundled Traefik v3 with native Gateway API provider (auto-provisioned Hetzner LB) |
| \`hcm-cilium.yaml\` | + Cilium 1.18 replacing Flannel + kube-proxy, native routing over the Hetzner private network, Gateway API |

All three bake in the fixes for the failure modes hit during validation: \`HCLOUD_LOAD_BALANCERS_LOCATION\` + \`USE_PRIVATE_IP\` for healthy LB provisioning, \`--disable=local-storage\` so \`hcloud-volumes\` is the sole default StorageClass, and pre-k3s detection of the private-network IP so kubelet's TLS cert SAN includes it from the first registration.

Cleartext source for every base64-encoded \`write_files.content\` field lives under \`manifests/\` alongside a \`regenerate-b64.sh\` helper — the cloud-configs are reviewable and tweakable without manual decode/encode cycles.

README covers prerequisites, placeholder substitution (with the LB-location-must-align-with-servers requirement), a Security section (\`loadBalancerSourceRanges\`, private-only LBs, public-NIC firewalls coexisting with \`USE_PRIVATE_IP\`), each baked-in failure mode, validation status (all three ✅ end-to-end on a cpx32 in \`fsn1\`), and references to the official HCCM docs.

---

AI assistance: Claude was used as support while drafting this PR with Human manual review.