### PR TITLE
Update GCC to 15.3.0 and patch libstdc++ atomic -Wtemplate-body

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -310,7 +310,7 @@ ARG MUSL_VERSION=1.2.6
 RUN wget -q http://musl.libc.org/releases/musl-${MUSL_VERSION}.tar.gz -O musl.tar.gz
 
 FROM sources-downloader-base AS gcc-download
-ARG GCC_VERSION=15.2.0
+ARG GCC_VERSION=15.3.0
 RUN wget -q http://mirror.netcologne.de/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz -O gcc.tar.xz
 
 FROM sources-downloader-base AS gmp-download
@@ -747,10 +747,11 @@ RUN tar -xf gcc.tar.xz && mv gcc-* gcc
 RUN tar -xf gmp.tar.bz2 && mv -v gmp-* gcc/gmp
 RUN tar -xf mpc.tar.xz && mv -v mpc-* gcc/mpc
 RUN tar -xf mpfr.tar.bz2 && mv -v mpfr-* gcc/mpfr
-
-RUN <<EOT bash
-    mkdir -p /sysroot/usr/include
-    cd gcc && mkdir -v build && cd build && ../configure --quiet \
+COPY patches/0001-gcc-atomic-template-body-gcc15.patch /gcc/
+RUN cd /gcc && patch -p1 < 0001-gcc-atomic-template-body-gcc15.patch
+RUN mkdir -p /sysroot/usr/include
+WORKDIR /gcc/build
+RUN ../configure --quiet \
         --prefix=/usr \
         --build=${BUILD_ARCH} \
         --host=${TARGET} \
@@ -762,10 +763,9 @@ RUN <<EOT bash
         --enable-long-long \
         --disable-libmudflap \
         --disable-multilib \
-        --disable-libsanitizer && \
-        make -s ARCH="${ARCH}" CROSS_COMPILE="${TARGET}-" -j${JOBS} -l${MAX_LOAD} && \
-        make -s ARCH="${ARCH}" CROSS_COMPILE="${TARGET}-" -j${JOBS} -l${MAX_LOAD} DESTDIR=/sysroot install ;
-EOT
+        --disable-libsanitizer
+RUN make -s ARCH="${ARCH}" CROSS_COMPILE="${TARGET}-" -j${JOBS} -l${MAX_LOAD}
+RUN make -s ARCH="${ARCH}" CROSS_COMPILE="${TARGET}-" -j${JOBS} -l${MAX_LOAD} DESTDIR=/sysroot install
 
 ###
 ### Make

--- a/patches/0001-gcc-atomic-template-body-gcc15.patch
+++ b/patches/0001-gcc-atomic-template-body-gcc15.patch
@@ -1,0 +1,21 @@
+Suppress -Wtemplate-body for libstdc++ std::atomic constexpr constructor.
+
+In C++11 mode the constexpr atomic(_Tp) constructor has a non-empty body
+(it conditionally calls __builtin_clear_padding). The header already
+suppresses the resulting -Wc++14-extensions diagnostic, but GCC 15's newer
+template-body checker re-reports the same constexpr-ctor-body violation
+under -Wtemplate-body, which is not silenced and breaks the gnu++0x
+precompiled header build during the cross toolchain bootstrap. Ignore that
+warning too, mirroring the existing pragma.
+
+--- a/libstdc++-v3/include/std/atomic
++++ b/libstdc++-v3/include/std/atomic
+@@ -242,7 +242,8 @@
+       atomic& operator=(const atomic&) volatile = delete;
+
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wc++14-extensions" // constexpr ctor body
++#pragma GCC diagnostic ignored "-Wtemplate-body" // constexpr ctor body, C++11
+       constexpr atomic(_Tp __i) noexcept : _M_i(__i)
+       {
+ #if __has_builtin(__builtin_clear_padding)


### PR DESCRIPTION
GCC 15.3.0 libstdc++ <atomic> has a constexpr atomic(_Tp) constructor with a non-empty body (conditional __builtin_clear_padding). This is ill-formed in C++11; the header silences the resulting -Wc++14-extensions diagnostic but not GCC 15's newer -Wtemplate-body checker, which re-reports it as a hard error and breaks the gnu++0x precompiled-header build during the cross toolchain bootstrap.

Add a patch that also ignores -Wtemplate-body for that constructor, mirroring the existing pragma, and bump GCC_VERSION to 15.3.0.