### PR TITLE
fix: decouple systemd SBAT version from build VERSION to keep compile cached

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,13 @@
 ARG BOOTLOADER=grub
 ARG KERNEL_TYPE=default
 ARG VERSION=0.0.1
+## SBAT distro-version string baked into the systemd-boot/stub EFI .sbat metadata.
+## Intentionally STABLE and decoupled from the per-commit build VERSION so the
+## (expensive) systemd compile stage stays cache-valid across commits. The SBAT
+## *generation* (the revocation counter that actually gates boot) is a separate
+## field that defaults to 1; bump SBAT_DISTRO_VERSION manually only on a
+## security-relevant SBAT revocation.
+ARG SBAT_DISTRO_VERSION=1
 ARG JOBS=16
 ## Maximum load for make -l
 ARG MAX_LOAD=32
@@ -3154,7 +3161,7 @@ RUN make -s ARCH=${BUILD_ARCH} install DESTDIR=/libucontext
 ## Try to build it at the end so we have most libraries already built
 ## Anything that depends on systemd should be built after this stage
 FROM rsync AS systemd
-ARG VERSION
+ARG SBAT_DISTRO_VERSION
 
 COPY --from=gperf /gperf /gperf
 RUN rsync -aHAX --keep-dirlinks  /gperf/. /
@@ -3284,7 +3291,7 @@ RUN /usr/bin/meson setup buildDir \
       -D sbat-distro="Hadron" \
       -D sbat-distro-url="hadron-linux.io" \
       -Dsbat-distro-summary="Hadron Linux" \
-      -Dsbat-distro-version="${VERSION}"
+      -Dsbat-distro-version="${SBAT_DISTRO_VERSION}"
 RUN ninja -C buildDir
 RUN DESTDIR=/systemd ninja -C buildDir install
 


### PR DESCRIPTION
## What

The `systemd` stage baked the per-commit build `VERSION` into the bootloader SBAT
metadata via `meson setup -Dsbat-distro-version="${VERSION}"`, immediately before
the full `ninja` systemd compile. Any change to `VERSION` busts that meson-setup
cache layer → full systemd recompile → rebuild of the **9 downstream stages** that
`COPY --from=systemd`.

In CI this is currently masked (`VERSION` is pinned to the branch ref / default
`0.0.1`), but local `make build-hadron` passes `git describe` as `VERSION`, so every
commit triggers a from-scratch systemd rebuild. It is also a latent CI landmine the
moment real per-commit versioning is wired in.

## Change

Replace the dependency with a dedicated, stable `SBAT_DISTRO_VERSION` arg (default
`1`). The SBAT *version string* is informational; the revocation *generation* counter
is a separate systemd field. Bumping the SBAT version is a deliberate distro decision
(e.g. a security revocation), not something that should ride along with every build's
`VERSION`. `os-release` `VERSION_ID` is untouched and still reflects the real build
`VERSION`.

Validated with `docker buildx build --check` (no warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)