### PR TITLE
ci: per-PR registry build cache for PR pipelines

### DIFF
--- a/.github/workflows/PR_amd64.yml
+++ b/.github/workflows/PR_amd64.yml
@@ -7,6 +7,16 @@ on:
 concurrency:
   group: ci-image-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
+
+env:
+  # Per-PR BuildKit cache. Each build job reads its own pr-<number>-* tag first
+  # (warm from a prior push or an earlier job in this same run) and falls back to
+  # the shared main cache tag. Only same-repo PRs can WRITE it (fork PRs have no
+  # secrets) — they still read the public cache. Stale pr-* tags are reclaimed by
+  # pr-cache-cleanup.yml when the PR closes.
+  PR_CACHE_WRITE: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+  PR_NUM: ${{ github.event.pull_request.number }}
+
 jobs:
   check-kernel-configs:
     runs-on: ubuntu-latest
@@ -51,6 +61,13 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
+      - name: Log in to quay.io (push per-PR build cache)
+        if: ${{ env.PR_CACHE_WRITE == 'true' }}
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_PASSWORD }}
       - name: Build PR
         uses: docker/build-push-action@v7
         env:
@@ -65,7 +82,9 @@ jobs:
             ${{ steps.meta.outputs.labels }}
             cache-label=quay-remote-amd64
           cache-from: |
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-toolchain-amd64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:toolchain-amd64,mode=max
+          cache-to: ${{ env.PR_CACHE_WRITE == 'true' && format('type=registry,ref=quay.io/kairos/hadron-build-cache:pr-{0}-toolchain-amd64,mode=max,ignore-error=true,compression=zstd,compression-level=3,oci-mediatypes=true,image-manifest=true', env.PR_NUM) || '' }}
           target: toolchain
   container:
     runs-on: oracle-vm-32cpu-128gb-x86-64
@@ -89,6 +108,13 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
+      - name: Log in to quay.io (push per-PR build cache)
+        if: ${{ env.PR_CACHE_WRITE == 'true' }}
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_PASSWORD }}
       - name: Build PR
         uses: docker/build-push-action@v7
         with:
@@ -104,8 +130,11 @@ jobs:
             ${{ steps.meta.outputs.labels }}
             cache-label=quay-remote-amd64
           cache-from: |
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-container-amd64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-toolchain-amd64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:toolchain-amd64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:container-amd64,mode=max
+          cache-to: ${{ env.PR_CACHE_WRITE == 'true' && format('type=registry,ref=quay.io/kairos/hadron-build-cache:pr-{0}-container-amd64,mode=max,ignore-error=true,compression=zstd,compression-level=3,oci-mediatypes=true,image-manifest=true', env.PR_NUM) || '' }}
           target: container
       - name: Test container image (build-time smoke)
         uses: docker/build-push-action@v7
@@ -118,6 +147,8 @@ jobs:
           platforms: linux/amd64
           target: container-test
           cache-from: |
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-container-amd64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-toolchain-amd64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:toolchain-amd64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:container-amd64,mode=max
       - name: Install Go
@@ -163,6 +194,13 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
+      - name: Log in to quay.io (push per-PR build cache)
+        if: ${{ env.PR_CACHE_WRITE == 'true' }}
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_PASSWORD }}
       - name: Build PR
         uses: docker/build-push-action@v7
         env:
@@ -180,9 +218,13 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           target: default
           cache-from: |
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-bios-${{ matrix.kernel }}-${{ matrix.fips }}-amd64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-container-amd64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-toolchain-amd64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:toolchain-amd64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:container-amd64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:bios-${{ matrix.kernel }}-${{ matrix.fips }}-amd64,mode=max
+          cache-to: ${{ env.PR_CACHE_WRITE == 'true' && format('type=registry,ref=quay.io/kairos/hadron-build-cache:pr-{0}-bios-{1}-{2}-amd64,mode=max,ignore-error=true,compression=zstd,compression-level=3,oci-mediatypes=true,image-manifest=true', env.PR_NUM, matrix.kernel, matrix.fips) || '' }}
           build-args: |
             BOOTLOADER=grub
             KERNEL_TYPE=${{ matrix.kernel }}
@@ -212,6 +254,13 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
+      - name: Log in to quay.io (push per-PR build cache)
+        if: ${{ env.PR_CACHE_WRITE == 'true' }}
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_PASSWORD }}
       - name: Build PR
         uses: docker/build-push-action@v7
         env:
@@ -227,9 +276,13 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           target: default
           cache-from: |
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-trusted-${{ matrix.kernel }}-amd64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-container-amd64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-toolchain-amd64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:toolchain-amd64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:container-amd64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:trusted-${{ matrix.kernel }}-amd64,mode=max
+          cache-to: ${{ env.PR_CACHE_WRITE == 'true' && format('type=registry,ref=quay.io/kairos/hadron-build-cache:pr-{0}-trusted-{1}-amd64,mode=max,ignore-error=true,compression=zstd,compression-level=3,oci-mediatypes=true,image-manifest=true', env.PR_NUM, matrix.kernel) || '' }}
           build-args: |
             BOOTLOADER=systemd
             KERNEL_TYPE=${{ matrix.kernel }}

--- a/.github/workflows/PR_amd64.yml
+++ b/.github/workflows/PR_amd64.yml
@@ -272,7 +272,7 @@ jobs:
           platforms: linux/amd64
           push: true
           provenance: false
-          tags: ttl.sh/hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-trusted:${{ github.sha }}
+          tags: ttl.sh/hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-trusted-${{ github.sha }}:24h
           labels: ${{ steps.meta.outputs.labels }}
           target: default
           cache-from: |
@@ -347,7 +347,7 @@ jobs:
           provenance: false
           tags: ttl.sh/hadron-init-trusted:${{ github.sha }}
           build-args: |
-            BASE_IMAGE=ttl.sh/hadron-cloud-trusted:${{ github.sha }}
+            BASE_IMAGE=ttl.sh/hadron-cloud-trusted-${{ github.sha }}:24h
             VERSION=v0.0.1-${{ github.sha }}
             TRUSTED_BOOT=true
   build-bios-iso:

--- a/.github/workflows/PR_arm64.yml
+++ b/.github/workflows/PR_arm64.yml
@@ -7,6 +7,16 @@ on:
 concurrency:
   group: ci-image-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
+
+env:
+  # Per-PR BuildKit cache. Each build job reads its own pr-<number>-* tag first
+  # (warm from a prior push or an earlier job in this same run) and falls back to
+  # the shared main cache tag. Only same-repo PRs can WRITE it (fork PRs have no
+  # secrets) — they still read the public cache. Stale pr-* tags are reclaimed by
+  # pr-cache-cleanup.yml when the PR closes.
+  PR_CACHE_WRITE: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+  PR_NUM: ${{ github.event.pull_request.number }}
+
 jobs:
   check-kernel-configs:
     runs-on: ubuntu-latest
@@ -51,6 +61,13 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
+      - name: Log in to quay.io (push per-PR build cache)
+        if: ${{ env.PR_CACHE_WRITE == 'true' }}
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_PASSWORD }}
       - name: Build PR
         uses: docker/build-push-action@v7
         env:
@@ -65,7 +82,9 @@ jobs:
             ${{ steps.meta.outputs.labels }}
           target: toolchain
           cache-from: |
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-toolchain-arm64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:toolchain-arm64,mode=max
+          cache-to: ${{ env.PR_CACHE_WRITE == 'true' && format('type=registry,ref=quay.io/kairos/hadron-build-cache:pr-{0}-toolchain-arm64,mode=max,ignore-error=true,compression=zstd,compression-level=3,oci-mediatypes=true,image-manifest=true', env.PR_NUM) || '' }}
           build-args: |
             ARCH=aarch64
             BUILD_ARCH=aarch64
@@ -91,6 +110,13 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
+      - name: Log in to quay.io (push per-PR build cache)
+        if: ${{ env.PR_CACHE_WRITE == 'true' }}
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_PASSWORD }}
       - name: Build PR
         uses: docker/build-push-action@v7
         env:
@@ -108,8 +134,11 @@ jobs:
             ${{ steps.meta.outputs.labels }}
           target: container
           cache-from: |
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-container-arm64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-toolchain-arm64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:toolchain-arm64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:container-arm64,mode=max
+          cache-to: ${{ env.PR_CACHE_WRITE == 'true' && format('type=registry,ref=quay.io/kairos/hadron-build-cache:pr-{0}-container-arm64,mode=max,ignore-error=true,compression=zstd,compression-level=3,oci-mediatypes=true,image-manifest=true', env.PR_NUM) || '' }}
           build-args: |
             ARCH=aarch64
             BUILD_ARCH=aarch64
@@ -122,6 +151,8 @@ jobs:
           platforms: linux/arm64
           target: container-test
           cache-from: |
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-container-arm64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-toolchain-arm64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:toolchain-arm64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:container-arm64,mode=max
           build-args: |
@@ -168,6 +199,13 @@ jobs:
         uses: docker/metadata-action@v6
       # ttl.sh tags must not match PR_amd64.yml: both workflows trigger on PRs with the same
       # github.sha last-writer wins, so amd64 BIOS jobs would silently pull linux/arm64.
+      - name: Log in to quay.io (push per-PR build cache)
+        if: ${{ env.PR_CACHE_WRITE == 'true' }}
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_PASSWORD }}
       - name: Build PR
         uses: docker/build-push-action@v7
         env:
@@ -183,9 +221,13 @@ jobs:
             ${{ steps.meta.outputs.labels }}
           target: default
           cache-from: |
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-grub-${{ matrix.kernel }}-arm64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-container-arm64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:pr-${{ env.PR_NUM }}-toolchain-arm64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:toolchain-arm64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:container-arm64,mode=max
             type=registry,ref=quay.io/kairos/hadron-build-cache:grub-${{ matrix.kernel }}-arm64,mode=max
+          cache-to: ${{ env.PR_CACHE_WRITE == 'true' && format('type=registry,ref=quay.io/kairos/hadron-build-cache:pr-{0}-grub-{1}-arm64,mode=max,ignore-error=true,compression=zstd,compression-level=3,oci-mediatypes=true,image-manifest=true', env.PR_NUM, matrix.kernel) || '' }}
           build-args: |
             BOOTLOADER=grub
             KERNEL_TYPE=${{ matrix.kernel }}

--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -1,0 +1,57 @@
+---
+name: 'PR cache cleanup'
+
+# When a PR closes (merged or not), delete the per-PR BuildKit cache tags
+# (pr-<number>-*) that PR_amd64.yml / PR_arm64.yml pushed to the shared cache
+# repo. Quay does not auto-expire these (the reason we use a registry cache and
+# not the GitHub-provided cache), so reclaim the space deterministically here.
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-cache-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  purge-pr-cache:
+    # Fork PRs never wrote cache (no access to secrets), so nothing to clean.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+      - name: Delete pr-<number>-* build cache tags
+        env:
+          QUAY_USER: ${{ secrets.QUAY_IO_USERNAME }}
+          QUAY_PASS: ${{ secrets.QUAY_IO_PASSWORD }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          CACHE_REPO: quay.io/kairos/hadron-build-cache
+        run: |
+          set -euo pipefail
+          printf '%s' "$QUAY_PASS" | skopeo login quay.io -u "$QUAY_USER" --password-stdin
+
+          prefix="pr-${PR_NUM}-"
+          # skopeo list-tags returns {"Repository": "...", "Tags": ["pr-123-toolchain-amd64", ...]}
+          tags=$(skopeo list-tags "docker://${CACHE_REPO}" \
+            | python3 -c "import sys, json; print('\n'.join(t for t in json.load(sys.stdin).get('Tags', []) if t.startswith('${prefix}')))")
+
+          if [ -z "${tags}" ]; then
+            echo "No ${prefix}* cache tags found; nothing to delete."
+            exit 0
+          fi
+
+          echo "Deleting cache tags for PR #${PR_NUM}:"
+          echo "${tags}"
+          while IFS= read -r tag; do
+            [ -n "${tag}" ] || continue
+            echo "==> deleting ${CACHE_REPO}:${tag}"
+            # Non-fatal: a missing tag or a transient registry error must not fail
+            # the cleanup for the remaining tags.
+            skopeo delete "docker://${CACHE_REPO}:${tag}" || echo "WARN: could not delete ${tag} (continuing)"
+          done <<< "${tags}"

--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -1,25 +1,34 @@
 ---
 name: 'PR cache cleanup'
 
-# When a PR closes (merged or not), delete the per-PR BuildKit cache tags
-# (pr-<number>-*) that PR_amd64.yml / PR_arm64.yml pushed to the shared cache
-# repo. Quay does not auto-expire these (the reason we use a registry cache and
-# not the GitHub-provided cache), so reclaim the space deterministically here.
+# Reclaim the per-PR BuildKit cache tags (pr-<number>-*) that PR_amd64.yml /
+# PR_arm64.yml push to the shared cache repo. Quay (public quay.io) has no
+# auto-expire / auto-prune for these, so we delete them ourselves:
+#   - purge-pr-cache:       on PR close, delete that PR's tags (normal path).
+#   - sweep-stale-pr-cache: weekly, delete pr-<n>-* tags whose PR is no longer
+#                           open (backstop for any close-cleanup that was missed).
 on:
   pull_request:
     types: [closed]
+  schedule:
+    - cron: '0 3 * * 0'  # weekly, Sunday 03:00 UTC
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
-  group: pr-cache-cleanup-${{ github.event.pull_request.number }}
+  group: pr-cache-cleanup-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false
+
+env:
+  CACHE_REPO: quay.io/kairos/hadron-build-cache
 
 jobs:
   purge-pr-cache:
-    # Fork PRs never wrote cache (no access to secrets), so nothing to clean.
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    # On PR close: drop just this PR's cache tags. Fork PRs never wrote cache
+    # (no access to secrets), so there is nothing to clean for them.
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Install skopeo
@@ -31,7 +40,6 @@ jobs:
           QUAY_USER: ${{ secrets.QUAY_IO_USERNAME }}
           QUAY_PASS: ${{ secrets.QUAY_IO_PASSWORD }}
           PR_NUM: ${{ github.event.pull_request.number }}
-          CACHE_REPO: quay.io/kairos/hadron-build-cache
         run: |
           set -euo pipefail
           printf '%s' "$QUAY_PASS" | skopeo login quay.io -u "$QUAY_USER" --password-stdin
@@ -53,5 +61,53 @@ jobs:
             echo "==> deleting ${CACHE_REPO}:${tag}"
             # Non-fatal: a missing tag or a transient registry error must not fail
             # the cleanup for the remaining tags.
+            skopeo delete "docker://${CACHE_REPO}:${tag}" || echo "WARN: could not delete ${tag} (continuing)"
+          done <<< "${tags}"
+
+  sweep-stale-pr-cache:
+    # Weekly backstop: delete pr-<n>-* tags whose PR number is NOT currently open.
+    # Catches stragglers from any missed/failed close-cleanup, and never touches an
+    # open PR's cache regardless of age (no date math needed).
+    if: ${{ github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+      - name: Delete pr-<n>-* tags for closed PRs
+        env:
+          QUAY_USER: ${{ secrets.QUAY_IO_USERNAME }}
+          QUAY_PASS: ${{ secrets.QUAY_IO_PASSWORD }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$QUAY_PASS" | skopeo login quay.io -u "$QUAY_USER" --password-stdin
+
+          # Numbers of all currently-open PRs (these must be preserved).
+          open=$(gh pr list --repo "$GH_REPO" --state open --limit 1000 --json number --jq '.[].number' | sort -u)
+          echo "Open PRs: $(echo "${open}" | tr '\n' ' ')"
+
+          tags=$(skopeo list-tags "docker://${CACHE_REPO}" \
+            | python3 -c "import sys, json; print('\n'.join(t for t in json.load(sys.stdin).get('Tags', []) if t.startswith('pr-')))")
+
+          if [ -z "${tags}" ]; then
+            echo "No pr-* cache tags found; nothing to sweep."
+            exit 0
+          fi
+
+          while IFS= read -r tag; do
+            [ -n "${tag}" ] || continue
+            n=$(printf '%s' "${tag}" | sed -nE 's/^pr-([0-9]+)-.*/\1/p')
+            if [ -z "${n}" ]; then
+              echo "skip (no PR number): ${tag}"
+              continue
+            fi
+            if echo "${open}" | grep -qx "${n}"; then
+              echo "keep (PR #${n} open): ${tag}"
+              continue
+            fi
+            echo "==> deleting stale ${CACHE_REPO}:${tag} (PR #${n} not open)"
             skopeo delete "docker://${CACHE_REPO}:${tag}" || echo "WARN: could not delete ${tag} (continuing)"
           done <<< "${tags}"


### PR DESCRIPTION
## Problem

amd64/arm64 PR builds only **read** the shared `main` BuildKit cache and never wrote
anything back (`cache-to` is guarded by `ref_name == 'main'`). So every push that
busted a stage recompiled it cold and **discarded** the result — the next push, and
each fan-out job within the same run, redid the work.

The GitHub-provided cache (`type=gha`) is unusable for Hadron: its ~10GB/repo cap
fills immediately for this from-source image, and it evicts older entries as soon as
more than one job competes. So this uses the existing **quay.io registry cache**.

## Change

Each build job now reads a per-PR tag first (`pr-<number>-<stage>-<arch>`), falls
back to the `main` cache tag, and writes its result back to the per-PR tag. This
warms the cache two ways:

- **intra-run:** the `container`/`bios`/`trusted`/`grub` jobs read *this PR's* freshly
  built `toolchain`/`container` layers instead of `main`'s (possibly stale) ones, so
  they stop recompiling the changed subtree;
- **inter-push:** a second push to the same PR reuses the prior push's compile and
  only rebuilds what actually changed.

Writes are guarded to same-repo PRs (fork PRs have no secrets — they still read the
public cache), mirroring the `ref_name=='main'` guard on the main pipeline. A quay.io
login step is added to each build job (the PR workflows previously only logged in to
ghcr.io, so `cache-to` would have silently 401'd).

`pr-cache-cleanup.yml` deletes the `pr-<number>-*` tags when the PR closes (quay does
not auto-expire them), bounding cache storage to open PRs.

## Requires

- The `QUAY_IO_USERNAME`/`QUAY_IO_PASSWORD` robot must have **write + delete** on
  `quay.io/kairos/hadron-build-cache` (write = cache push, delete = cleanup).
- Optional belt-and-suspenders: a Quay auto-prune policy with a `^pr-` tag-regex
  filter, to catch stragglers if a cleanup run is ever missed.

Not runtime-tested (needs runners + secrets); YAML + expression syntax validated and
logic mirrors the working `main` pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)