### PR TITLE
ci: skip image build + tests for PRs that don't touch build inputs

### DIFF
--- a/.github/workflows/PR_amd64.yml
+++ b/.github/workflows/PR_amd64.yml
@@ -8,7 +8,37 @@ concurrency:
   group: ci-image-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
+  # Classify the PR diff. Only run the (expensive) image build + QEMU tests when a
+  # file that actually affects the image changes. Docs / markdown / examples /
+  # bump-config-only PRs skip straight to ci-ok. Extend the 'build' filter below if
+  # a new build input is added to the repo.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      build: ${{ steps.filter.outputs.build }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            build:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - 'Makefile'
+              - 'patches/**'
+              - 'files/**'
+              - 'tests/**'
+              - '.github/scripts/**'
+              - '.github/workflows/PR_amd64.yml'
+
   check-kernel-configs:
+    needs: changes
+    if: ${{ needs.changes.outputs.build == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,6 +62,8 @@ jobs:
           exit $FAILED
 
   toolchain:
+    needs: changes
+    if: ${{ needs.changes.outputs.build == 'true' }}
     runs-on: oracle-vm-32cpu-128gb-x86-64
     permissions:
       packages: write
@@ -538,3 +570,40 @@ jobs:
         with:
           header: image-size-report
           path: report.md
+
+  # Single required status check. Point branch protection at THIS job (and drop the
+  # individual build/test jobs from the required list), otherwise a docs-only PR
+  # that skips them would leave their required checks pending forever. ci-ok passes
+  # when every pipeline job either succeeded or was skipped, and fails if any job
+  # failed or was cancelled.
+  ci-ok:
+    if: ${{ always() }}
+    needs:
+      - changes
+      - check-kernel-configs
+      - toolchain
+      - container
+      - hadron-bios
+      - hadron-trusted
+      - build-kairos-bios
+      - build-kairos-trusted
+      - build-bios-iso
+      - build-trusted-iso
+      - tests-bios
+      - tests-trusted
+      - tests-bios-fips
+      - image-size-report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check pipeline result
+        run: |
+          echo "Job results: ${{ join(needs.*.result, ' ') }}"
+          for r in ${{ join(needs.*.result, ' ') }}; do
+            case "$r" in
+              failure|cancelled)
+                echo "::error::A required job did not pass (result: $r)"
+                exit 1
+                ;;
+            esac
+          done
+          echo "All required jobs passed or were skipped."

--- a/.github/workflows/PR_amd64.yml
+++ b/.github/workflows/PR_amd64.yml
@@ -571,12 +571,13 @@ jobs:
           header: image-size-report
           path: report.md
 
-  # Single required status check. Point branch protection at THIS job (and drop the
-  # individual build/test jobs from the required list), otherwise a docs-only PR
-  # that skips them would leave their required checks pending forever. ci-ok passes
-  # when every pipeline job either succeeded or was skipped, and fails if any job
-  # failed or was cancelled.
-  ci-ok:
+  # Single required status check for this arch. Point branch protection at THIS job
+  # (and drop the individual build/test jobs from the required list), otherwise a
+  # docs-only PR that skips them would leave their required checks pending forever.
+  # Each arch has its own ci-ok-<arch> job so branch protection can require them
+  # independently. ci-ok passes when every pipeline job either succeeded or was
+  # skipped, and fails if any job failed or was cancelled.
+  ci-ok-amd64:
     if: ${{ always() }}
     needs:
       - changes

--- a/.github/workflows/PR_arm64.yml
+++ b/.github/workflows/PR_arm64.yml
@@ -276,12 +276,13 @@ jobs:
           name: kairos-hadron-bios-${{ github.sha }}.iso.zip
           path: build/*.iso
 
-  # Single required status check. Point branch protection at THIS job (and drop the
-  # individual build jobs from the required list), otherwise a docs-only PR that
-  # skips them would leave their required checks pending forever. ci-ok passes when
-  # every pipeline job either succeeded or was skipped, and fails if any job failed
-  # or was cancelled.
-  ci-ok:
+  # Single required status check for this arch. Point branch protection at THIS job
+  # (and drop the individual build jobs from the required list), otherwise a
+  # docs-only PR that skips them would leave their required checks pending forever.
+  # Each arch has its own ci-ok-<arch> job so branch protection can require them
+  # independently. ci-ok passes when every pipeline job either succeeded or was
+  # skipped, and fails if any job failed or was cancelled.
+  ci-ok-arm64:
     if: ${{ always() }}
     needs:
       - changes

--- a/.github/workflows/PR_arm64.yml
+++ b/.github/workflows/PR_arm64.yml
@@ -8,7 +8,37 @@ concurrency:
   group: ci-image-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
+  # Classify the PR diff. Only run the (expensive) image build when a file that
+  # actually affects the image changes. Docs / markdown / examples / bump-config-only
+  # PRs skip straight to ci-ok. Extend the 'build' filter below if a new build input
+  # is added to the repo.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      build: ${{ steps.filter.outputs.build }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            build:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - 'Makefile'
+              - 'patches/**'
+              - 'files/**'
+              - 'tests/**'
+              - '.github/scripts/**'
+              - '.github/workflows/PR_arm64.yml'
+
   check-kernel-configs:
+    needs: changes
+    if: ${{ needs.changes.outputs.build == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,6 +62,8 @@ jobs:
           exit $FAILED
 
   toolchain:
+    needs: changes
+    if: ${{ needs.changes.outputs.build == 'true' }}
     runs-on: oracle-vm-32cpu-128gb-arm64
     permissions:
       packages: write
@@ -243,6 +275,36 @@ jobs:
         with:
           name: kairos-hadron-bios-${{ github.sha }}.iso.zip
           path: build/*.iso
+
+  # Single required status check. Point branch protection at THIS job (and drop the
+  # individual build jobs from the required list), otherwise a docs-only PR that
+  # skips them would leave their required checks pending forever. ci-ok passes when
+  # every pipeline job either succeeded or was skipped, and fails if any job failed
+  # or was cancelled.
+  ci-ok:
+    if: ${{ always() }}
+    needs:
+      - changes
+      - check-kernel-configs
+      - toolchain
+      - container
+      - hadron-grub
+      - build-kairos-grub
+      - build-grub-iso
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check pipeline result
+        run: |
+          echo "Job results: ${{ join(needs.*.result, ' ') }}"
+          for r in ${{ join(needs.*.result, ' ') }}; do
+            case "$r" in
+              failure|cancelled)
+                echo "::error::A required job did not pass (result: $r)"
+                exit 1
+                ;;
+            esac
+          done
+          echo "All required jobs passed or were skipped."
 
 # This test requires changes onto PEG to support ARM architecture properly.
 #  Uncomment when PEG supports ARM testing


### PR DESCRIPTION
## What

~1/3 of PRs touch only docs / markdown / examples / bump-config and never affect the
image, yet they run the full `toolchain → container → image → iso (→ QEMU tests)`
pipeline on the oracle-vm runners.

A `changes` job (`dorny/paths-filter`) classifies the PR diff. The two root jobs
(`check-kernel-configs`, `toolchain`) are gated on `needs.changes.outputs.build`;
every other job already chains off them via `needs`, so they cascade-skip
automatically when no build input changed.

`build` filter (the real image inputs): `Dockerfile`, `.dockerignore`, `Makefile`,
`patches/**`, `files/**`, `tests/**`, `.github/scripts/**`, and the PR workflow
itself. Extend it if a new build input is added. (Note: autobumper PRs edit
`ARG *_VERSION` in `Dockerfile`, so they correctly count as a build.)

## ⚠ Required manual step (branch protection)

Skipping a required status check would otherwise leave a PR pending forever, so a
`ci-ok` aggregator (`if: always()`) is added — it passes when every pipeline job
either **succeeded or was skipped** and fails if any **failed or was cancelled**.

**Before/with merge:** point branch protection at **`ci-ok`** and **remove the
individual build/test jobs** (toolchain, container, hadron-*, tests-*, …) from the
required-checks list. Otherwise docs-only PRs (which skip those jobs) can never go
green.

riscv is untouched (pipeline disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)