### PR TITLE
attach a report of package versions in the release notes

### DIFF
--- a/.github/workflows/build-multiarch-images.yml
+++ b/.github/workflows/build-multiarch-images.yml
@@ -1403,3 +1403,44 @@ jobs:
           done
           echo "Could not push history after retries" >&2
           exit 1
+
+  release-notes:
+    name: Update release notes with component manifest
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Generate component manifest (markdown)
+        run: ./hack/gen-components.sh --ref "${GITHUB_REF_NAME}" --name release --out-dir . --format md
+
+      - name: Create or update the GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          {
+            echo
+            echo "## 📦 Shipped components"
+            echo
+            cat release.md
+          } > notes-append.md
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            # Append to the existing notes, preserving them.
+            gh release view "$TAG" --json body --jq .body > existing.md || : > existing.md
+            cat existing.md notes-append.md > final.md
+            gh release edit "$TAG" --notes-file final.md
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes
+            gh release view "$TAG" --json body --jq .body > existing.md || : > existing.md
+            cat existing.md notes-append.md > final.md
+            gh release edit "$TAG" --notes-file final.md
+          fi

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,8 +4,14 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
     paths:
       - 'docs/**'
+      - 'Dockerfile'
+      - 'updatecli.d/**'
+      - 'hack/gen-components.sh'
+      - 'hack/gen-snapshot.sh'
       - '.github/workflows/gh-pages.yml'
   workflow_dispatch:
 
@@ -30,6 +36,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -44,6 +51,9 @@ jobs:
       - name: Install dependencies
         working-directory: ./docs
         run: npm ci
+
+      - name: Generate component snapshots
+        run: ./hack/gen-snapshot.sh
 
       - name: Build with Docusaurus
         working-directory: ./docs

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+    # Note: the `paths:` filter below applies to tag pushes too, so a `v*` tag
+    # that points at an existing commit (touching none of the filtered paths)
+    # will NOT trigger this workflow. That's intentional: tag manifests are
+    # regenerated on every main build (eventual consistency), so new tags
+    # appear on the next main rebuild. The `tags:` trigger only fires
+    # immediately when a tag push also touches one of the filtered paths.
     tags:
       - 'v*'
     paths:

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ actionlint
 
 files/hadron-splash/*.o
 files/hadron-splash/hadron
+
+# Generated component manifest (build artifacts)
+/components.json
+/components.md

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ files/hadron-splash/hadron
 # Generated component manifest (build artifacts)
 /components.json
 /components.md
+/docs/static/components/

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,8 @@ targets:
 	@echo "build-iso: Build the GRUB or Trusted Boot ISO image based on the BOOTLOADER variable. Expects the Hadron+Kairos OCI images to be built already."
 	@echo "grub-iso: Build the GRUB ISO image. Expects the Hadron+Kairos OCI images to be built already."
 	@echo "trusted-iso: Build the Trusted Boot ISO image. Expects the Hadron+Kairos OCI images to be built already."
+	@echo "components: Generate components.json + components.md for the working tree"
+	@echo "test-components: Run the component-generator shell test"
 
 .PHONY: help
 help: targets
@@ -259,3 +261,11 @@ bump-deps:
 	@echo "Installing bump tool and updating dependencies..."
 	@go install github.com/wader/bump/cmd/bump@latest
 	@bump update
+
+.PHONY: components
+components: ## Generate components.json + components.md for the working tree
+	./hack/gen-components.sh --format both --out-dir .
+
+.PHONY: test-components
+test-components: ## Run the component-generator shell test
+	sh ./hack/gen-components_test.sh

--- a/hack/gen-components.sh
+++ b/hack/gen-components.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# Generate a grouped component/version manifest from the Hadron Dockerfile.
+set -eu
+
+REF="worktree"
+NAME="components"
+OUT_DIR="."
+FORMAT="both"
+DATE="${SOURCE_DATE_EPOCH:-}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ref)     REF="$2";     shift 2 ;;
+    --name)    NAME="$2";    shift 2 ;;
+    --out-dir) OUT_DIR="$2"; shift 2 ;;
+    --format)  FORMAT="$2";  shift 2 ;;
+    --date)    DATE="$2";    shift 2 ;;
+    -h|--help) echo "usage: gen-components.sh [--ref REF] [--name BASENAME] [--out-dir DIR] [--format json|md|both] [--date STR]"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+ROOT="${HADRON_ROOT:-$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)}"
+
+# --- Resolve Dockerfile content + commit + display ref ---
+if [ "$REF" = "worktree" ] || [ -z "$REF" ]; then
+  DOCKERFILE_CONTENT="$(cat "$ROOT/Dockerfile")"
+  COMMIT="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  REF_NAME="worktree"
+else
+  DOCKERFILE_CONTENT="$(git -C "$ROOT" show "${REF}:Dockerfile")"
+  COMMIT="$(git -C "$ROOT" rev-parse --short "$REF" 2>/dev/null || echo unknown)"
+  REF_NAME="$REF"
+fi
+
+GROUPS_TMP="$(mktemp)"
+ROWS_TMP="$(mktemp)"
+trap 'rm -f "$GROUPS_TMP" "$ROWS_TMP"' EXIT
+
+# --- ARG -> group map from updatecli.d ---
+for f in "$ROOT"/updatecli.d/*.yaml; do
+  [ -e "$f" ] || continue
+  group="$(basename "$f" .yaml | tr '-' ' ' \
+    | awk '{for(i=1;i<=NF;i++)$i=toupper(substr($i,1,1)) substr($i,2); print}')"
+  grep -oE 'matcher: [A-Z0-9_]+_VERSION' "$f" 2>/dev/null \
+    | sed -E 's/matcher: //' \
+    | while IFS= read -r arg; do
+        printf '%s\t%s\n' "$arg" "$group" >> "$GROUPS_TMP"
+      done
+done
+
+# --- Parse ARG *_VERSION= lines into GROUP<TAB>NAME<TAB>VERSION rows ---
+printf '%s\n' "$DOCKERFILE_CONTENT" \
+  | grep -E '^ARG [A-Z0-9_]+_VERSION=' \
+  | while IFS= read -r line; do
+      arg="$(printf '%s' "$line" | sed -E 's/^ARG ([A-Z0-9_]+_VERSION)=.*/\1/')"
+      val="$(printf '%s' "$line" | sed -E 's/^ARG [A-Z0-9_]+_VERSION=//; s/^"//; s/"$//; s/[[:space:]].*$//')"
+      group="$(awk -F'\t' -v a="$arg" '$1==a{print $2; exit}' "$GROUPS_TMP")"
+      [ -n "$group" ] || group="Other"
+      name="$(printf '%s' "$arg" | sed -E 's/_VERSION$//' | tr 'A-Z_' 'a-z-')"
+      printf '%s\t%s\t%s\n' "$group" "$name" "$val" >> "$ROWS_TMP"
+    done
+
+# Stable ordering: group, then component
+TAB="$(printf '\t')"
+sort -t"$TAB" -k1,1 -k2,2 "$ROWS_TMP" -o "$ROWS_TMP"
+
+gen_json() {
+  awk -F'\t' -v ref="$REF_NAME" -v commit="$COMMIT" -v date="$DATE" '
+    BEGIN { printf "{\n  \"ref\": \"%s\",\n  \"commit\": \"%s\",\n  \"generated\": \"%s\",\n  \"groups\": {\n", ref, commit, date }
+    {
+      if ($1 != curgroup) {
+        if (curgroup != "") printf "\n    },\n"
+        printf "    \"%s\": {\n", $1
+        curgroup=$1; first=1
+      }
+      if (!first) printf ",\n"
+      printf "      \"%s\": \"%s\"", $2, $3
+      first=0
+    }
+    END { if (curgroup != "") printf "\n    }\n"; printf "  }\n}\n" }
+  ' "$ROWS_TMP"
+}
+
+gen_md() {
+  printf '# Hadron components — %s\n\n' "$REF_NAME"
+  printf 'Commit: `%s`\n\n' "$COMMIT"
+  awk -F'\t' '
+    {
+      if ($1 != curgroup) {
+        if (curgroup != "") printf "\n"
+        printf "### %s\n\n| Component | Version |\n|-----------|---------|\n", $1
+        curgroup=$1
+      }
+      printf "| %s | %s |\n", $2, $3
+    }
+  ' "$ROWS_TMP"
+}
+
+mkdir -p "$OUT_DIR"
+case "$FORMAT" in
+  json) gen_json > "$OUT_DIR/$NAME.json" ;;
+  md)   gen_md   > "$OUT_DIR/$NAME.md" ;;
+  both) gen_json > "$OUT_DIR/$NAME.json"; gen_md > "$OUT_DIR/$NAME.md" ;;
+  *) echo "unknown format: $FORMAT" >&2; exit 2 ;;
+esac

--- a/hack/gen-components_test.sh
+++ b/hack/gen-components_test.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Self-contained, no-network test for hack/gen-components.sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+GEN="$SCRIPT_DIR/gen-components.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- Fixture repo root ---
+mkdir -p "$WORK/updatecli.d"
+cat > "$WORK/Dockerfile" <<'EOF'
+ARG KERNEL_VERSION=9.9.9
+ARG SYSTEMD_VERSION=260.2
+ARG MUSSEL_VERSION="abc123"
+ARG SOMETHING_ELSE=notaversion
+EOF
+cat > "$WORK/updatecli.d/kernel-and-boot.yaml" <<'EOF'
+targets:
+  kernel:
+    spec:
+      instruction:
+        matcher: KERNEL_VERSION
+EOF
+cat > "$WORK/updatecli.d/core-system.yaml" <<'EOF'
+targets:
+  systemd:
+    spec:
+      instruction:
+        matcher: SYSTEMD_VERSION
+EOF
+
+# --- Run generator against the fixture ---
+HADRON_ROOT="$WORK" "$GEN" --ref worktree --name components --out-dir "$WORK" --format both --date "2026-06-25"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+JSON="$WORK/components.json"
+MD="$WORK/components.md"
+
+[ -f "$JSON" ] || fail "components.json not created"
+[ -f "$MD" ]   || fail "components.md not created"
+
+# kernel parsed and grouped
+grep -q '"kernel": "9.9.9"' "$JSON" || fail "kernel version/name wrong in JSON"
+grep -q '"Kernel And Boot"' "$JSON" || fail "Kernel And Boot group missing in JSON"
+
+# quoted value stripped + uncovered ARG -> Other
+grep -q '"mussel": "abc123"' "$JSON" || fail "mussel quote-strip/name wrong in JSON"
+grep -q '"Other"' "$JSON"            || fail "Other group missing in JSON"
+
+# non *_VERSION ARG excluded
+grep -q 'something' "$JSON" && fail "SOMETHING_ELSE should be excluded"
+
+# markdown headings
+grep -q '### Kernel And Boot' "$MD" || fail "MD missing Kernel And Boot heading"
+grep -q '### Other' "$MD"           || fail "MD missing Other heading"
+grep -q '| kernel | 9.9.9 |' "$MD"  || fail "MD missing kernel row"
+
+# JSON is valid if python3 is available
+if command -v python3 >/dev/null 2>&1; then
+  python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$JSON" || fail "components.json is not valid JSON"
+fi
+
+echo "PASS: gen-components tests"

--- a/hack/gen-snapshot.sh
+++ b/hack/gen-snapshot.sh
@@ -19,8 +19,12 @@ TAGS="$(git -C "$ROOT" tag -l 'v*' --sort=-version:refname || true)"
   || "$GEN" --ref worktree --name main --out-dir "$OUT" --format both --date "$DATE"
 
 for tag in $TAGS; do
-  "$GEN" --ref "$tag" --name "$tag" --out-dir "$OUT" --format both --date "$DATE"
-  REFS="$REFS $tag"
+  # Skip (don't abort under set -e) any tag whose manifest can't be generated.
+  if "$GEN" --ref "$tag" --name "$tag" --out-dir "$OUT" --format both --date "$DATE"; then
+    REFS="$REFS $tag"
+  else
+    echo "warning: skipping tag $tag (could not generate manifest)" >&2
+  fi
 done
 
 # index.json

--- a/hack/gen-snapshot.sh
+++ b/hack/gen-snapshot.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Generate per-ref component manifests + an index into docs/static/components/.
+set -eu
+
+ROOT="${HADRON_ROOT:-$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)}"
+OUT="$ROOT/docs/static/components"
+GEN="$ROOT/hack/gen-components.sh"
+DATE="${SOURCE_DATE_EPOCH:-}"
+
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+# Refs: main first, then every v* tag (version-sorted, newest first)
+REFS="main"
+TAGS="$(git -C "$ROOT" tag -l 'v*' --sort=-version:refname || true)"
+
+# main snapshot (use current checkout's Dockerfile if HEAD is main)
+"$GEN" --ref main --name main --out-dir "$OUT" --format both --date "$DATE" \
+  || "$GEN" --ref worktree --name main --out-dir "$OUT" --format both --date "$DATE"
+
+for tag in $TAGS; do
+  "$GEN" --ref "$tag" --name "$tag" --out-dir "$OUT" --format both --date "$DATE"
+  REFS="$REFS $tag"
+done
+
+# index.json
+{
+  printf '['
+  sep=''
+  for r in $REFS; do printf '%s"%s"' "$sep" "$r"; sep=', '; done
+  printf ']\n'
+} > "$OUT/index.json"
+
+# index.html (lightweight, no framework)
+{
+  echo '<!doctype html><html><head><meta charset="utf-8">'
+  echo '<title>Hadron component manifests</title>'
+  echo '<style>body{font-family:system-ui,sans-serif;max-width:48rem;margin:2rem auto;padding:0 1rem}li{margin:.3rem 0}</style>'
+  echo '</head><body><h1>Hadron component manifests</h1>'
+  echo '<p>Component/version snapshot for each Hadron build.</p><ul>'
+  for r in $REFS; do
+    printf '<li><strong>%s</strong> — <a href="./%s.md">markdown</a> · <a href="./%s.json">json</a></li>\n' "$r" "$r" "$r"
+  done
+  echo '</ul></body></html>'
+} > "$OUT/index.html"

--- a/hack/gen-snapshot.sh
+++ b/hack/gen-snapshot.sh
@@ -35,15 +35,171 @@ done
   printf ']\n'
 } > "$OUT/index.json"
 
-# index.html (lightweight, no framework)
-{
-  echo '<!doctype html><html><head><meta charset="utf-8">'
-  echo '<title>Hadron component manifests</title>'
-  echo '<style>body{font-family:system-ui,sans-serif;max-width:48rem;margin:2rem auto;padding:0 1rem}li{margin:.3rem 0}</style>'
-  echo '</head><body><h1>Hadron component manifests</h1>'
-  echo '<p>Component/version snapshot for each Hadron build.</p><ul>'
-  for r in $REFS; do
-    printf '<li><strong>%s</strong> — <a href="./%s.md">markdown</a> · <a href="./%s.json">json</a></li>\n' "$r" "$r" "$r"
-  done
-  echo '</ul></body></html>'
-} > "$OUT/index.html"
+# index.html (self-contained, no framework — fetches index.json + <ref>.json at runtime)
+cat > "$OUT/index.html" <<'HTML'
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Hadron · Component Manifests</title>
+<meta name="description" content="Component and version manifest for every Hadron Linux build — kernel and all upstream components, per release.">
+<style>
+  :root{
+    --bg0:#071026; --bg1:#0e2540; --accent:#1baaff; --accent2:#7fd4ff;
+    --pop:#ee5007; --text:#eaf2fb; --muted:#9fb3c8;
+    --card:rgba(255,255,255,.04); --border:rgba(27,170,255,.18); --border2:rgba(27,170,255,.32);
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{
+    font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+    color:var(--text); background:linear-gradient(145deg,var(--bg0),var(--bg1)) fixed;
+    min-height:100vh; line-height:1.5;
+  }
+  a{color:var(--accent2); text-decoration:none}
+  a:hover{text-decoration:underline}
+  .wrap{max-width:1080px; margin:0 auto; padding:2.2rem 1.2rem 4rem}
+  header{display:flex; align-items:center; gap:.9rem; margin-bottom:.4rem}
+  header img{height:42px; width:auto}
+  header .titles h1{font-size:1.5rem; margin:0; font-weight:650; letter-spacing:.2px}
+  header .titles p{margin:.15rem 0 0; color:var(--muted); font-size:.92rem}
+  .controls{
+    position:sticky; top:0; z-index:5; margin:1.4rem 0 1.6rem; padding:.85rem 1rem;
+    display:flex; flex-wrap:wrap; align-items:center; gap:.8rem;
+    background:rgba(7,16,38,.82); backdrop-filter:blur(8px);
+    border:1px solid var(--border); border-radius:12px;
+  }
+  .controls label{font-size:.8rem; color:var(--muted); text-transform:uppercase; letter-spacing:.6px; margin-right:.1rem}
+  select,input[type=search]{
+    background:#0a1a33; color:var(--text); border:1px solid var(--border2);
+    border-radius:8px; padding:.5rem .7rem; font-size:.95rem; font-family:inherit;
+  }
+  select:focus,input:focus{outline:2px solid var(--accent); outline-offset:1px}
+  input[type=search]{flex:1; min-width:160px}
+  .meta{margin-left:auto; display:flex; align-items:center; gap:.9rem; font-size:.85rem; color:var(--muted)}
+  .chip{background:rgba(27,170,255,.12); border:1px solid var(--border); color:var(--accent2);
+    border-radius:999px; padding:.18rem .6rem; font-size:.78rem; white-space:nowrap}
+  .raw a{margin-left:.55rem; font-size:.85rem}
+  .grid{display:grid; grid-template-columns:repeat(auto-fill,minmax(300px,1fr)); gap:1rem}
+  .group{background:var(--card); border:1px solid var(--border); border-radius:12px; padding:.2rem 0 .4rem; overflow:hidden}
+  .group.other{border-color:rgba(238,80,7,.28)}
+  .group h2{
+    display:flex; align-items:center; justify-content:space-between; gap:.5rem;
+    font-size:.82rem; text-transform:uppercase; letter-spacing:.8px; color:var(--accent2);
+    margin:0; padding:.75rem 1rem .55rem; border-bottom:1px solid var(--border);
+  }
+  .group.other h2{color:#ffb27a}
+  .group h2 .cnt{font-size:.72rem; color:var(--muted); background:rgba(255,255,255,.05);
+    border-radius:999px; padding:.1rem .5rem; letter-spacing:.4px}
+  .row{display:flex; align-items:baseline; justify-content:space-between; gap:1rem;
+    padding:.34rem 1rem; font-size:.92rem}
+  .row:nth-child(even){background:rgba(255,255,255,.018)}
+  .row .name{color:var(--text)}
+  .row .ver{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; font-size:.85rem;
+    color:var(--accent); text-align:right; word-break:break-all; max-width:55%}
+  .empty{color:var(--muted); padding:2rem 1rem; text-align:center}
+  footer{margin-top:2.6rem; color:var(--muted); font-size:.82rem; border-top:1px solid var(--border); padding-top:1.1rem}
+  .hide{display:none}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <img src="/images/hadron-logo.svg" alt="Hadron" onerror="this.style.display='none'">
+    <div class="titles">
+      <h1>Component Manifests</h1>
+      <p>The exact upstream component versions shipped in each Hadron build.</p>
+    </div>
+  </header>
+
+  <div class="controls">
+    <label for="ref">Release</label>
+    <select id="ref" aria-label="Select a release"></select>
+    <input id="filter" type="search" placeholder="Filter components…" aria-label="Filter components" autocomplete="off">
+    <div class="meta">
+      <span class="chip" id="commit"></span>
+      <span class="chip" id="count"></span>
+      <span class="raw" id="raw"></span>
+    </div>
+  </div>
+
+  <div id="content" class="grid"></div>
+  <div id="empty" class="empty hide">No components match your filter.</div>
+
+  <footer>
+    Generated from the Hadron <code>Dockerfile</code> · machine-readable JSON available per release ·
+    <a href="https://github.com/kairos-io/hadron">github.com/kairos-io/hadron</a>
+  </footer>
+</div>
+
+<script>
+(function(){
+  var refSel=document.getElementById('ref'), filterEl=document.getElementById('filter'),
+      content=document.getElementById('content'), emptyEl=document.getElementById('empty'),
+      commitEl=document.getElementById('commit'), countEl=document.getElementById('count'),
+      rawEl=document.getElementById('raw');
+  var current=null;
+
+  function esc(s){return String(s).replace(/[&<>"]/g,function(c){
+    return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];});}
+
+  function render(){
+    if(!current){return;}
+    var q=(filterEl.value||'').trim().toLowerCase();
+    var groups=current.groups||{}, names=Object.keys(groups), shown=0, html='';
+    names.forEach(function(g){
+      var comps=groups[g]||{}, keys=Object.keys(comps);
+      var rows=keys.filter(function(k){
+        return !q || k.toLowerCase().indexOf(q)>=0 || String(comps[k]).toLowerCase().indexOf(q)>=0;
+      });
+      if(!rows.length){return;}
+      shown+=rows.length;
+      var isOther=g.toLowerCase()==='other';
+      html+='<section class="group'+(isOther?' other':'')+'">'+
+        '<h2>'+esc(g)+'<span class="cnt">'+rows.length+'</span></h2>';
+      rows.forEach(function(k){
+        html+='<div class="row"><span class="name">'+esc(k)+'</span>'+
+              '<span class="ver">'+esc(comps[k])+'</span></div>';
+      });
+      html+='</section>';
+    });
+    content.innerHTML=html;
+    emptyEl.classList.toggle('hide', shown>0);
+  }
+
+  function total(m){var n=0,g=m.groups||{};Object.keys(g).forEach(function(k){n+=Object.keys(g[k]).length;});return n;}
+
+  function load(ref){
+    fetch('./'+encodeURIComponent(ref)+'.json',{cache:'no-cache'}).then(function(r){return r.json();}).then(function(m){
+      current=m;
+      commitEl.textContent=m.commit?('commit '+m.commit):'';
+      commitEl.style.display=m.commit?'':'none';
+      countEl.textContent=total(m)+' components';
+      rawEl.innerHTML='<a href="./'+ref+'.json">json</a><a href="./'+ref+'.md">markdown</a>';
+      if(location.hash.slice(1)!==ref){history.replaceState(null,'','#'+ref);}
+      render();
+    }).catch(function(){content.innerHTML='<div class="empty">Could not load manifest for '+esc(ref)+'.</div>';});
+  }
+
+  fetch('./index.json',{cache:'no-cache'}).then(function(r){return r.json();}).then(function(refs){
+    refs.forEach(function(ref){
+      var o=document.createElement('option'); o.value=ref;
+      o.textContent=ref==='main'?'main (latest)':ref; refSel.appendChild(o);
+    });
+    var want=location.hash.slice(1);
+    var start=(want&&refs.indexOf(want)>=0)?want:refs[0];
+    refSel.value=start; load(start);
+  });
+
+  refSel.addEventListener('change',function(){load(refSel.value);});
+  filterEl.addEventListener('input',render);
+  window.addEventListener('hashchange',function(){
+    var h=location.hash.slice(1);
+    if(h && h!==refSel.value){refSel.value=h; load(h);}
+  });
+})();
+</script>
+</body>
+</html>
+HTML


### PR DESCRIPTION
This PR adds scaffolding to generate versions of packages included in the hadron image during build, and it also generates a page in gh-page that is front-facing showing the current versions in the image.