### PR TITLE
feat(pam): STIG password complexity, history and last-login (#4058 finding 6)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -368,6 +368,19 @@ FROM sources-downloader-base AS pam-download
 ARG PAM_VERSION=1.7.2
 RUN wget -q https://github.com/linux-pam/linux-pam/releases/download/v${PAM_VERSION}/Linux-PAM-${PAM_VERSION}.tar.xz -O pam.tar.xz
 
+FROM sources-downloader-base AS cracklib-download
+ARG CRACKLIB_VERSION=2.10.3
+RUN wget -q https://github.com/cracklib/cracklib/releases/download/v${CRACKLIB_VERSION}/cracklib-${CRACKLIB_VERSION}.tar.xz -O cracklib.tar.xz
+RUN wget -q https://github.com/cracklib/cracklib/releases/download/v${CRACKLIB_VERSION}/cracklib-words-${CRACKLIB_VERSION}.bz2 -O cracklib-words.bz2
+
+FROM sources-downloader-base AS libpwquality-download
+ARG LIBPWQUALITY_VERSION=1.4.5
+RUN wget -q https://github.com/libpwquality/libpwquality/releases/download/libpwquality-${LIBPWQUALITY_VERSION}/libpwquality-${LIBPWQUALITY_VERSION}.tar.bz2 -O libpwquality.tar.bz2
+
+FROM sources-downloader-base AS lastlog2-download
+ARG LASTLOG2_VERSION=1.2.0
+RUN wget -q https://github.com/thkukuk/lastlog2/releases/download/v${LASTLOG2_VERSION}/lastlog2-${LASTLOG2_VERSION}.tar.xz -O lastlog2.tar.xz
+
 FROM sources-downloader-base AS shadow-download
 ARG SHADOW_VERSION=4.19.4
 RUN wget -q https://github.com/shadow-maint/shadow/releases/download/${SHADOW_VERSION}/shadow-${SHADOW_VERSION}.tar.xz -O shadow.tar.xz
@@ -672,6 +685,10 @@ COPY --from=nfs-utils-download /sources/downloads/nfs-utils.tar.xz /sources/down
 COPY --from=cryptsetup-download /sources/downloads/cryptsetup.tar.xz /sources/downloads/
 COPY --from=grub-download /sources/downloads/grub.tar.xz /sources/downloads/
 COPY --from=pam-download /sources/downloads/pam.tar.xz /sources/downloads/
+COPY --from=cracklib-download /sources/downloads/cracklib.tar.xz /sources/downloads/
+COPY --from=cracklib-download /sources/downloads/cracklib-words.bz2 /sources/downloads/
+COPY --from=libpwquality-download /sources/downloads/libpwquality.tar.bz2 /sources/downloads/
+COPY --from=lastlog2-download /sources/downloads/lastlog2.tar.xz /sources/downloads/
 COPY --from=shadow-download /sources/downloads/shadow.tar.xz /sources/downloads/
 COPY --from=aports-download /sources/downloads/aports.tar.gz /sources/downloads/
 COPY --from=busybox-download /sources/downloads/busybox.tar.bz2 /sources/downloads/
@@ -1805,6 +1822,83 @@ RUN pip3 install meson ninja
 RUN meson setup buildDir --prefix=/usr --buildtype=minsize -Dstrip=true
 RUN DESTDIR=/pam ninja -j${JOBS} -C buildDir install
 COPY files/pam/* /pam/etc/pam.d/
+
+
+# cracklib: dictionary-based password checking, dependency of libpwquality (STIG #6)
+FROM rsync AS cracklib
+ARG JOBS
+COPY --from=pkgconfig /pkgconfig /pkgconfig
+RUN rsync -aHAX --keep-dirlinks  /pkgconfig/. /
+COPY --from=sources-downloader /sources/downloads/cracklib.tar.xz /sources/
+# Rename the wordlist so it does not collide with the `cracklib-*` extract glob below.
+COPY --from=sources-downloader /sources/downloads/cracklib-words.bz2 /sources/words.bz2
+RUN mkdir -p /cracklib
+WORKDIR /sources
+RUN tar -xf cracklib.tar.xz && mv cracklib-*/ cracklib
+WORKDIR /sources/cracklib
+# Install into DESTDIR (to ship) and into / (so the freshly built cracklib-packer
+# and libcrack are runnable in the next step).
+RUN ./configure ${COMMON_CONFIGURE_ARGS} --disable-dependency-tracking --disable-nls --without-python --sysconfdir=/etc && \
+    make -s -j${JOBS} -l${MAX_LOAD} DESTDIR=/cracklib install && \
+    make -s -j${JOBS} -l${MAX_LOAD} install
+# Build the cracklib dictionary from the official wordlist with the just-built
+# cracklib-packer (runs natively or under binfmt on every arch; the 2.10 dict
+# format is byte-order-aware, so pw_dict is valid on every little-endian target).
+# We do NOT use create-cracklib-dict/cracklib-format here: that script relies on
+# GNU `gzip -cdf` (busybox gzip errors on non-gzip input) and `tr -cd '[:graph:]'`
+# (busybox tr treats the class as literal chars), which together silently reduced
+# a 1.9M-word list to ~14k garbage entries. Instead format the list with
+# busybox-safe operators (grep for the class, tr only for case) and pipe straight
+# to cracklib-packer. The trailing ls fails the build loudly if no dict resulted.
+RUN mkdir -p /cracklib/usr/share/cracklib && \
+    bunzip2 -c /sources/words.bz2 \
+      | grep -av '^#' \
+      | tr 'A-Z' 'a-z' \
+      | grep -aE '^[[:graph:]]+$' \
+      | cut -c1-1022 \
+      | LC_ALL=C sort -u \
+      | cracklib-packer /cracklib/usr/share/cracklib/pw_dict && \
+    ls -l /cracklib/usr/share/cracklib/pw_dict.pwd
+
+
+# libpwquality: provides pam_pwquality.so + pwscore (STIG #6 password complexity)
+FROM rsync AS libpwquality
+ARG JOBS
+COPY --from=pkgconfig /pkgconfig /pkgconfig
+RUN rsync -aHAX --keep-dirlinks  /pkgconfig/. /
+COPY --from=cracklib /cracklib /cracklib
+RUN rsync -aHAX --keep-dirlinks  /cracklib/. /
+COPY --from=pam /pam /pam
+RUN rsync -aHAX --keep-dirlinks  /pam/. /
+COPY --from=sources-downloader /sources/downloads/libpwquality.tar.bz2 /sources/
+RUN mkdir -p /libpwquality
+WORKDIR /sources
+RUN tar -xf libpwquality.tar.bz2 && mv libpwquality-* libpwquality
+WORKDIR /sources/libpwquality
+RUN ./configure ${COMMON_CONFIGURE_ARGS} --disable-dependency-tracking --disable-nls \
+    --disable-python-bindings --enable-pam --sysconfdir=/etc \
+    --with-securedir=/usr/lib/security && \
+    make -s -j${JOBS} -l${MAX_LOAD} DESTDIR=/libpwquality install
+
+
+# lastlog2: pam_lastlog2.so + lastlog2 CLI (STIG #6 last-login; replaces the
+# pam_lastlog module removed upstream in PAM 1.6). sqlite-backed db in /var/lib/lastlog.
+FROM python-build AS lastlog2
+ARG JOBS
+COPY --from=pkgconfig /pkgconfig /pkgconfig
+RUN rsync -aHAX --keep-dirlinks  /pkgconfig/. /
+COPY --from=pam /pam /pam
+RUN rsync -aHAX --keep-dirlinks  /pam/. /
+COPY --from=sqlite3 /sqlite3 /sqlite3
+RUN rsync -aHAX --keep-dirlinks  /sqlite3/. /
+COPY --from=sources-downloader /sources/downloads/lastlog2.tar.xz /sources/
+RUN mkdir -p /lastlog2
+WORKDIR /sources
+RUN tar -xf lastlog2.tar.xz && mv lastlog2-* lastlog2
+WORKDIR /sources/lastlog2
+RUN pip3 install meson ninja
+RUN meson setup buildDir --prefix=/usr --buildtype=minsize -Dstrip=true -Dpamlibdir=/usr/lib/security -Dman=false
+RUN DESTDIR=/lastlog2 ninja -j${JOBS} -C buildDir install
 
 
 # shadow-base only deps
@@ -4227,6 +4321,21 @@ RUN rsync -aHAX --keep-dirlinks  /libseccomp/. /skeleton/
 # copy pam but with systemd support
 COPY --from=pam-systemd /pam /pam
 RUN rsync -aHAX --keep-dirlinks  /pam/. /skeleton
+
+# STIG #6: cracklib + libpwquality (pam_pwquality, pwscore, pw_dict) and
+# lastlog2 (pam_lastlog2). Full image only - the minimal container has no PAM.
+COPY --from=cracklib /cracklib /cracklib
+RUN rsync -aHAX --keep-dirlinks  /cracklib/. /skeleton
+COPY --from=libpwquality /libpwquality /libpwquality
+RUN rsync -aHAX --keep-dirlinks  /libpwquality/. /skeleton
+# pam_lastlog2 links liblastlog2 -> libsqlite3, which is otherwise only a build
+# dep and not shipped, so add the sqlite3 shared library (lib only, no CLI/headers).
+COPY --from=sqlite3 /sqlite3 /sqlite3
+RUN rsync -aHAX --keep-dirlinks  /sqlite3/usr/lib/. /skeleton/usr/lib/
+COPY --from=lastlog2 /lastlog2 /lastlog2
+RUN rsync -aHAX --keep-dirlinks  /lastlog2/. /skeleton
+# Hardened pwquality policy overrides libpwquality's commented default.
+COPY files/security/pwquality.conf /skeleton/etc/security/pwquality.conf
 
 # copy shadow but with systemd support
 COPY --from=shadow-systemd /shadow /shadow

--- a/files/pam/system-auth
+++ b/files/pam/system-auth
@@ -15,7 +15,12 @@ account    required                    pam_unix.so
 account    optional                    pam_permit.so
 account    required                    pam_time.so
 
-password   required                    pam_unix.so          try_first_pass nullok sha512 shadow
+# STIG: enforce password complexity (pam_pwquality, see /etc/security/pwquality.conf)
+# and password history (pam_pwhistory, opasswd) before pam_unix stores the hash.
+# nullok is intentionally dropped so empty passwords cannot be set.
+password   requisite                   pam_pwquality.so     retry=3 enforce_for_root
+password   requisite                   pam_pwhistory.so     use_authtok remember=5 retry=3 enforce_for_root
+password   required                    pam_unix.so          try_first_pass sha512 shadow use_authtok
 password   optional                    pam_permit.so
 
 session    required                    pam_limits.so

--- a/files/pam/system-login
+++ b/files/pam/system-login
@@ -17,4 +17,7 @@ session    optional   pam_motd.so
 session    optional   pam_mail.so          dir=/var/spool/mail standard quiet
 session    optional   pam_umask.so
 -session   optional   pam_systemd.so
+# STIG: record and display last login (pam_lastlog was removed in PAM 1.6,
+# replaced by pam_lastlog2 backed by /var/lib/lastlog/lastlog2.db).
+session    optional   pam_lastlog2.so      showfailed
 session    required   pam_env.so

--- a/files/security/pwquality.conf
+++ b/files/security/pwquality.conf
@@ -1,0 +1,31 @@
+# STIG / GPOS-SRG password-quality policy for Hadron.
+# Read by pam_pwquality.so (libpwquality). Values follow the RHEL 9 STIG.
+#
+# NOTE: this only gates *interactive* password changes (the PAM `password`
+# stack, e.g. `passwd`). Kairos/yip provisioning writes the password hash
+# straight to /etc/shadow and never invokes PAM, so a weak password in a
+# cloud-init config still provisions; the policy applies when a user changes
+# their own password on a running system.
+
+# Minimum length (SV-258048).
+minlen = 15
+# Require at least one character of each class (SV-258050/052/054, ocredit).
+ucredit = -1
+lcredit = -1
+dcredit = -1
+ocredit = -1
+# At least 4 character classes in the new password (SV-258064).
+minclass = 4
+# Limit consecutive identical characters (SV-258060) and same-class runs (SV-258062).
+maxrepeat = 3
+maxclassrepeat = 4
+# Number of characters that must differ from the old password (SV-258066).
+difok = 8
+# Reject passwords found in the cracklib dictionary (SV-258068).
+dictcheck = 1
+# Check the GECOS fields so names/usernames can't be used as passwords.
+gecoscheck = 1
+# Apply the policy to root as well (full-STIG posture).
+enforce_for_root
+# Prompts before giving up.
+retry = 3

--- a/tests/acceptance_test.go
+++ b/tests/acceptance_test.go
@@ -211,6 +211,9 @@ openssl x509 -in /etc/ssl/certs/ca-cert-hadron-custom-ca.pem -noout -subject`)
 			Expect(strings.TrimSpace(out)).To(Equal("1"))
 		})
 
+		assertPamPasswordPolicy(vm)
+		assertLastlog2(vm)
+
 		By("checking corresponding state", func() {
 			out, err := vm.Sudo("kairos-agent state")
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -224,3 +224,63 @@ func assertLoginDefsHardening(vm VM) {
 		Expect(out).To(MatchRegexp(`(?m)^UMASK\s+077\b`), "UMASK should be 077")
 	})
 }
+
+// assertPamPasswordPolicy verifies the STIG password-complexity hardening
+// (kairos-io/kairos#4058 finding 6): pam_pwquality + pam_pwhistory are present,
+// the hardened /etc/security/pwquality.conf ships, the modules are wired into
+// the password stack (with nullok removed), and the policy functionally rejects
+// weak passwords while accepting a strong one (which also proves the cracklib
+// dictionary loaded). pwquality only gates interactive password changes; yip
+// provisions by writing /etc/shadow directly, so this does not affect login.
+func assertPamPasswordPolicy(vm VM) {
+	By("checking the STIG PAM password-complexity stack is present", func() {
+		out, err := vm.Sudo("ls /usr/lib/security/pam_pwquality.so /usr/lib/security/pam_pwhistory.so")
+		Expect(err).ToNot(HaveOccurred(), out)
+		out, err = vm.Sudo("command -v pwscore")
+		Expect(err).ToNot(HaveOccurred(), out)
+	})
+	By("checking the hardened pwquality.conf values", func() {
+		out, err := vm.Sudo("cat /etc/security/pwquality.conf")
+		Expect(err).ToNot(HaveOccurred(), out)
+		for _, want := range []string{"minlen = 15", "minclass = 4", "dictcheck = 1", "enforce_for_root"} {
+			Expect(out).To(ContainSubstring(want), "pwquality.conf missing %q", want)
+		}
+	})
+	By("checking pwquality/pwhistory are wired into the password stack (no nullok)", func() {
+		out, err := vm.Sudo("cat /etc/pam.d/system-auth")
+		Expect(err).ToNot(HaveOccurred(), out)
+		Expect(out).To(MatchRegexp(`(?m)^password\s+requisite\s+pam_pwquality\.so`))
+		Expect(out).To(MatchRegexp(`(?m)^password\s+requisite\s+pam_pwhistory\.so`))
+		Expect(out).ToNot(MatchRegexp(`(?m)^password\s+.*pam_unix\.so.*\bnullok\b`),
+			"nullok must be removed from the password stack")
+	})
+	By("checking pwquality rejects a weak password and accepts a strong one", func() {
+		// weak -> non-zero exit (also exercises the cracklib dictcheck)
+		_, err := vm.Sudo("echo 'weak' | pwscore")
+		Expect(err).To(HaveOccurred(), "pwscore should reject a weak password")
+		// strong -> score printed, exit 0 (proves pw_dict loaded and the policy passes)
+		out, err := vm.Sudo("echo 'Zr7#kPq2!mNv4@Lx' | pwscore")
+		Expect(err).ToNot(HaveOccurred(), out)
+	})
+}
+
+// assertLastlog2 verifies the pam_lastlog2 last-login hardening
+// (kairos-io/kairos#4058 finding 6; pam_lastlog was removed upstream in PAM 1.6).
+// The module + CLI ship, and the current SSH session - which logs in through
+// sshd -> system-login -> pam_lastlog2 - is recorded in the sqlite db.
+func assertLastlog2(vm VM) {
+	By("checking pam_lastlog2 module and CLI are present", func() {
+		out, err := vm.Sudo("ls /usr/lib/security/pam_lastlog2.so")
+		Expect(err).ToNot(HaveOccurred(), out)
+		out, err = vm.Sudo("command -v lastlog2")
+		Expect(err).ToNot(HaveOccurred(), out)
+	})
+	By("checking the SSH login was recorded by pam_lastlog2", func() {
+		out, err := vm.Sudo("test -f /var/lib/lastlog/lastlog2.db && echo OK")
+		Expect(err).ToNot(HaveOccurred(), out)
+		Expect(out).To(ContainSubstring("OK"))
+		records, err := vm.Sudo("lastlog2")
+		Expect(err).ToNot(HaveOccurred(), records)
+		Expect(records).To(ContainSubstring(user()))
+	})
+}

--- a/tests/image_structure_test.go
+++ b/tests/image_structure_test.go
@@ -193,6 +193,46 @@ var _ = Describe("hadron container image structure", Label("image-structure"), f
 			"found python bytecode artifacts that should be removed:\n%s", out)
 	})
 
+	It("ships the STIG PAM password-complexity stack (full image)", func() {
+		skipUnlessFullImage()
+		// modules + tooling present
+		out, code := shInImage(
+			"ls /usr/lib/security/pam_pwquality.so /usr/lib/security/pam_pwhistory.so " +
+				"/usr/lib/security/pam_lastlog2.so && command -v pwscore lastlog2")
+		Expect(code).To(Equal(0), out)
+		// hardened policy shipped
+		cfg, code := shInImage("cat /etc/security/pwquality.conf")
+		Expect(code).To(Equal(0), cfg)
+		for _, want := range []string{
+			"minlen = 15", "dcredit = -1", "ucredit = -1", "lcredit = -1",
+			"ocredit = -1", "minclass = 4", "dictcheck = 1", "enforce_for_root",
+		} {
+			Expect(cfg).To(ContainSubstring(want), "pwquality.conf missing %q", want)
+		}
+		// cracklib dictionary present (dictcheck would silently no-op without it)
+		_, code = shInImage("ls /usr/share/cracklib/pw_dict.pwd")
+		Expect(code).To(Equal(0), "cracklib pw_dict not shipped")
+		// wired into the password stack that passwd uses, with nullok removed
+		sa, code := shInImage("cat /etc/pam.d/system-auth")
+		Expect(code).To(Equal(0), sa)
+		Expect(sa).To(MatchRegexp(`(?m)^password\s+requisite\s+pam_pwquality\.so`))
+		Expect(sa).To(MatchRegexp(`(?m)^password\s+requisite\s+pam_pwhistory\.so`))
+		Expect(sa).ToNot(MatchRegexp(`(?m)^password\s+.*pam_unix\.so.*\bnullok\b`),
+			"nullok must be removed from the password stack")
+	})
+
+	It("wires pam_lastlog2 into the login session stack (full image)", func() {
+		skipUnlessFullImage()
+		// tmpfiles entry that creates the db directory at boot
+		tf, code := shInImage("cat /usr/lib/tmpfiles.d/lastlog2.conf")
+		Expect(code).To(Equal(0), tf)
+		Expect(tf).To(ContainSubstring("/var/lib/lastlog"))
+		// session hook present in the login stack
+		sl, code := shInImage("cat /etc/pam.d/system-login")
+		Expect(code).To(Equal(0), sl)
+		Expect(sl).To(MatchRegexp(`(?m)^session\s+optional\s+pam_lastlog2\.so`))
+	})
+
 	DescribeTable("top-level dirs are symlinks into usr",
 		func(dir, wantTarget string) {
 			// -L: path is a symlink. Then compare the readlink target.

--- a/tests/uki_test.go
+++ b/tests/uki_test.go
@@ -219,6 +219,8 @@ func genericTests(vm VM) {
 	assertSysctlHardening(vm)
 	assertLegacyNetDisabled(vm)
 	assertLoginDefsHardening(vm)
+	assertPamPasswordPolicy(vm)
+	assertLastlog2(vm)
 	assertInstallRecoveryServicesAbsent(vm)
 	By("Checking sysext was copied during boot", func() {
 		out, err := vm.Sudo("ls /run/extensions")


### PR DESCRIPTION
## Summary

Implements **PAM password-quality hardening** from the STIG spike (kairos-io/kairos#4058, finding 6) for the full Hadron image. Follow-up to #474 (which shipped findings 1/2/4/8).

### New build packages (full image only — the minimal `container` target has no PAM)
- **cracklib 2.10.3** — dictionary backend. `pw_dict` is generated at build time from the official wordlist (~1.9M words) with the freshly built `cracklib-packer` (runs natively or under binfmt on every arch; the 2.10 format is byte-order-aware → valid on all little-endian targets). We do **not** use `create-cracklib-dict`/`cracklib-format`: those assume GNU `gzip`/`tr` and silently produce a ~14k-word garbage dict under busybox (busybox `gzip -cdf` errors on non-gzip input; `tr -cd '[:graph:]'` treats the class as literal chars). Instead the list is formatted with busybox-safe operators and piped straight to `cracklib-packer`, with an `ls` guard so an empty dict fails the build.
- **libpwquality 1.4.5** — `pam_pwquality.so` + `pwscore`, built `--enable-pam` against cracklib, `securedir=/usr/lib/security`.
- **lastlog2 1.2.0** — `pam_lastlog2.so` + `lastlog2` CLI (`pam_lastlog` was removed upstream in linux-PAM 1.6). sqlite-backed db at `/var/lib/lastlog/lastlog2.db`, created by its shipped `tmpfiles.d` entry. `libsqlite3` was previously build-only, so the shared lib is now shipped into the full image so the module can load.

### PAM stack / config
- `files/pam/system-auth`: add `pam_pwquality` (`retry=3 enforce_for_root`) and `pam_pwhistory` (`remember=5 use_authtok`) before `pam_unix`, and **drop `nullok`** (no empty passwords).
- `files/pam/system-login`: add `pam_lastlog2.so showfailed` to the session stack.
- `files/security/pwquality.conf`: RHEL 9 STIG values (minlen 15, one of each class, minclass 4, maxrepeat 3, maxclassrepeat 4, difok 8, dictcheck, gecoscheck, `enforce_for_root`).

### Provisioning safety
This only gates **interactive** password changes. Kairos/yip provisions by writing the `/etc/shadow` hash directly (`mudler/yip` `pkg/plugins/user.go` — no `chpasswd`/PAM), and login uses the pam_unix **auth** stack (hash compare), so weak cloud-init passwords still provision and `enforce_for_root` is safe to ship. Existing test credentials are unchanged.

## Testing

- **Built the full amd64 image locally** (`make build-hadron ARCH=amd64`) and verified against it: `pwscore` rejects weak / accepts strong (dict loads, ~1.9M-word dict shipped), modules + libs resolve (`pam_pwquality→libpwquality→libcrack→libz`; `pam_lastlog2→liblastlog2→libsqlite3`).
- **`image-structure` suite: 26 passed / 0 failed** against the built image (new pwquality + lastlog2 specs run, gated by `skipUnlessFullImage`).
- New VM assertions `assertPamPasswordPolicy` + `assertLastlog2` wired into the `acceptance` and `uki` specs (modules present, hardened `pwquality.conf`, wired into `system-auth` without `nullok`, `pwscore` reject/accept; lastlog2 records the SSH login). These run on the QEMU acceptance jobs in CI (amd64/arm64/riscv64 + FIPS).

Part of kairos-io/kairos#4058.

🤖 Generated with [Claude Code](https://claude.com/claude-code)