### PR TITLE
feat: per-image component version manifest baked into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4093,6 +4093,36 @@ RUN find /skeleton -name "*.pyc" -delete
 RUN find /skeleton -name "__pycache__" -type d -exec rm -rf {} +
 
 # Container base image, it has the minimal required to run as a container
+# ------------------------------------------------------------------------------
+# Component version manifest
+# Parses the `ARG *_VERSION=` defaults from this very Dockerfile and emits a flat
+# `{ "name": "version" }` JSON per shipped image. The version map is intersected
+# with the packages each image's merge stages actually `COPY --from`, so each
+# image gets an accurate, per-image component list. Self-contained: generated at
+# build time from the Dockerfile itself (single source of truth, no host step).
+#
+# The full-image stage list is variant-aware: `full-image-merge-${FIPS}` selects
+# the fips/no-fips merge (fips adds libkcapi) and `full-image-pre-${BOOTLOADER}`
+# selects the grub/systemd path (grub adds dracut). This keeps the manifest in
+# step with what each FIPS/BOOTLOADER build actually ships.
+# Output is consumed by `container` and `full-image-final` below.
+# ------------------------------------------------------------------------------
+FROM alpine-base AS components
+ARG FIPS
+ARG BOOTLOADER
+COPY Dockerfile /src/Dockerfile
+COPY hack/gen-components.sh /src/hack/gen-components.sh
+# In fips builds the shipped `openssl` is the `FROM openssl-${FIPS} AS openssl`
+# alias built from the FIPS sources (OPENSSL_FIPS_VERSION), not OPENSSL_VERSION —
+# same component name, different version. --override reflects that.
+RUN cd /src && \
+    OVERRIDE=""; [ "${FIPS}" = "fips" ] && OVERRIDE="--override openssl=OPENSSL_FIPS_VERSION"; \
+    sh hack/gen-components.sh --shipped "stage2-merge" \
+       --format flat --name container --out-dir /out && \
+    sh hack/gen-components.sh \
+       --shipped "stage2-merge full-image-merge-base full-image-merge-${FIPS} full-image-pre-${BOOTLOADER} full-image-pre-preset full-image-final" \
+       ${OVERRIDE} --format flat --name full-image --out-dir /out
+
 FROM scratch AS container
 ARG VERSION
 COPY --from=stage2-merge /skeleton /
@@ -4109,6 +4139,8 @@ RUN if [ "${ARCH}" == "aarch64" ]; then \
     fi
 # Set the version here as otherwise its easy to invalidate the cache with a version change
 RUN echo "VERSION_ID=\"${VERSION}\"" >> etc/os-release
+# Per-image component manifest (late layer: only busts when a shipped version changes)
+COPY --from=components /out/container.json /usr/lib/hadron/components.json
 CMD ["/bin/bash", "-l"]
 
 # Target that tests to see if the binaries work or we are missing some libs
@@ -4453,6 +4485,8 @@ RUN if [ "${BUILD_ARCH}" == "aarch64" ]; then \
     else \
     ln -s /lib/ld-musl-x86_64.so.1 /bin/ldd; \
     fi
+# Per-image component manifest (late layer: only busts when a shipped version changes)
+COPY --from=components /out/full-image.json /usr/lib/hadron/components.json
 
 ## final image with debug
 FROM full-image-final AS debug

--- a/Makefile
+++ b/Makefile
@@ -267,5 +267,6 @@ components: ## Generate components.json + components.md for the working tree
 	./hack/gen-components.sh --format both --out-dir .
 
 .PHONY: test-components
-test-components: ## Run the component-generator shell test
+test-components: ## Run the component-generator shell tests
 	sh ./hack/gen-components_test.sh
+	sh ./hack/gen-components_shipped_test.sh

--- a/hack/gen-components.sh
+++ b/hack/gen-components.sh
@@ -7,6 +7,8 @@ NAME="components"
 OUT_DIR="."
 FORMAT="both"
 DATE="${SOURCE_DATE_EPOCH:-}"
+SHIPPED=""
+OVERRIDE=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -15,7 +17,9 @@ while [ $# -gt 0 ]; do
     --out-dir) OUT_DIR="$2"; shift 2 ;;
     --format)  FORMAT="$2";  shift 2 ;;
     --date)    DATE="$2";    shift 2 ;;
-    -h|--help) echo "usage: gen-components.sh [--ref REF] [--name BASENAME] [--out-dir DIR] [--format json|md|both] [--date STR]"; exit 0 ;;
+    --shipped)  SHIPPED="$2";  shift 2 ;;
+    --override) OVERRIDE="$2"; shift 2 ;;
+    -h|--help) echo "usage: gen-components.sh [--ref REF] [--name BASENAME] [--out-dir DIR] [--format json|md|flat|both] [--date STR] [--shipped \"STAGE...\"] [--override \"NAME=ARG...\"]"; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
@@ -65,6 +69,59 @@ printf '%s\n' "$DOCKERFILE_CONTENT" \
 TAB="$(printf '\t')"
 sort -t"$TAB" -k1,1 -k2,2 "$ROWS_TMP" -o "$ROWS_TMP"
 
+# --- Optional: restrict to components actually shipped in given merge stage(s) ---
+# A component "ships" in a stage if that stage has a `COPY --from=<build-stage>`
+# whose name maps to it. Build-stage names are normalized the same way as ARG
+# names (lowercase, `_`->`-`), with a few suffix rules for two-pass / variant
+# stages (`pam-systemd`->`pam`, `grub-efi`->`grub`, `kernel-modules`->`kernel`).
+if [ -n "$SHIPPED" ]; then
+  ALLOWED_TMP="$(mktemp)"
+  trap 'rm -f "$GROUPS_TMP" "$ROWS_TMP" "$ALLOWED_TMP"' EXIT
+  for st in $SHIPPED; do
+    printf '%s\n' "$DOCKERFILE_CONTENT" | awk -v st="$st" '
+      $0 ~ "^FROM .* AS "st"$" { inb=1; next }
+      inb && /^FROM / { inb=0 }
+      inb && /^[ \t]*COPY --from=/ {
+        line=$0; sub(/.*--from=/, "", line); sub(/[ \t].*/, "", line); print line
+      }'
+  done \
+    | tr 'A-Z_' 'a-z-' \
+    | sed -E 's/-systemd$//; s/-final$//; s/-build$//; s/-efi$//; s/-bios$//; s/-stage0$//; s/^kernel-modules$/kernel/' \
+    | sed -E 's/^libseccomp$/seccomp/; s/^xz$/xzutils/; s/^openscsi$/open-scsi/' \
+    | sort -u > "$ALLOWED_TMP"
+
+  # Keep only rows whose component name is in the allowed (shipped) set.
+  FILTERED_TMP="$(mktemp)"
+  awk -F'\t' 'NR==FNR { a[$1]=1; next } ($2 in a)' "$ALLOWED_TMP" "$ROWS_TMP" > "$FILTERED_TMP"
+  mv "$FILTERED_TMP" "$ROWS_TMP"
+
+  # Log shipped names that had no matching *_VERSION ARG (mapping gaps / inter-stage refs).
+  awk -F'\t' 'NR==FNR { have[$2]=1; next } !($1 in have) { print $1 }' "$ROWS_TMP" "$ALLOWED_TMP" \
+    | while IFS= read -r miss; do
+        echo "note: shipped stage ref '$miss' has no *_VERSION ARG (skipped)" >&2
+      done
+fi
+
+# --- Version overrides: "component=ARG_NAME" pairs ---
+# Sets a shipped component's version from a different ARG while keeping its
+# on-disk name. Models `FROM <name>-${VAR} AS <name>` alias stages that swap the
+# built version per build arg — e.g. `openssl=OPENSSL_FIPS_VERSION` in fips
+# builds, where the shipped `openssl` is built from the FIPS sources (3.1.2).
+if [ -n "$OVERRIDE" ]; then
+  for ov in $OVERRIDE; do
+    cname="${ov%%=*}"
+    argn="${ov#*=}"
+    val="$(printf '%s\n' "$DOCKERFILE_CONTENT" | grep -E "^ARG ${argn}=" | head -1 \
+      | sed -E "s/^ARG ${argn}=//; s/^\"//; s/\"\$//; s/[[:space:]].*\$//")"
+    if [ -z "$val" ]; then
+      echo "note: --override '$ov': ARG $argn not found, skipping" >&2
+      continue
+    fi
+    awk -F'\t' -v c="$cname" -v v="$val" 'BEGIN { OFS="\t" } $2==c { $3=v } { print }' \
+      "$ROWS_TMP" > "$ROWS_TMP.ov" && mv "$ROWS_TMP.ov" "$ROWS_TMP"
+  done
+fi
+
 gen_json() {
   awk -F'\t' -v ref="$REF_NAME" -v commit="$COMMIT" -v date="$DATE" '
     BEGIN { printf "{\n  \"ref\": \"%s\",\n  \"commit\": \"%s\",\n  \"generated\": \"%s\",\n  \"groups\": {\n", ref, commit, date }
@@ -97,10 +154,25 @@ gen_md() {
   ' "$ROWS_TMP"
 }
 
+# Flat `{ "name": "version", ... }` map, sorted by component name. Intended for
+# machine consumption (the in-image manifest) — no groups, no metadata.
+gen_flat() {
+  sort -t"$TAB" -k2,2 "$ROWS_TMP" | awk -F'\t' '
+    BEGIN { print "{"; first=1 }
+    {
+      if (!first) printf ",\n"
+      printf "  \"%s\": \"%s\"", $2, $3
+      first=0
+    }
+    END { if (first) print "}"; else printf "\n}\n" }
+  '
+}
+
 mkdir -p "$OUT_DIR"
 case "$FORMAT" in
   json) gen_json > "$OUT_DIR/$NAME.json" ;;
   md)   gen_md   > "$OUT_DIR/$NAME.md" ;;
+  flat) gen_flat > "$OUT_DIR/$NAME.json" ;;
   both) gen_json > "$OUT_DIR/$NAME.json"; gen_md > "$OUT_DIR/$NAME.md" ;;
   *) echo "unknown format: $FORMAT" >&2; exit 2 ;;
 esac

--- a/hack/gen-components_shipped_test.sh
+++ b/hack/gen-components_shipped_test.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+# Self-contained, no-network test for the --shipped / --format flat
+# per-image filtering in hack/gen-components.sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+GEN="$SCRIPT_DIR/gen-components.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/updatecli.d"
+# Fixture: 4 versioned components, two merge stages.
+# - stage2-merge ships curl + openssl (the minimal container set)
+# - full-image-merge-base inherits stage2-merge, adds kernel + pam (via the
+#   two-pass `pam-systemd` build stage, whose name must strip to `pam`)
+cat > "$WORK/Dockerfile" <<'EOF'
+ARG CURL_VERSION=8.20.0
+ARG OPENSSL_VERSION=3.6.3
+ARG KERNEL_VERSION=7.1.1
+ARG PAM_VERSION=1.7.0
+ARG SECCOMP_VERSION=2.6.0
+ARG XZUTILS_VERSION=5.8.3
+ARG OPEN_SCSI_VERSION=2.1.11
+ARG OPENSSL_FIPS_VERSION=3.1.2
+
+ARG PAXUTILS_VERSION=1.3.10
+
+FROM scratch AS stage2-merge
+COPY --from=curl /curl /curl
+RUN rsync /curl/. /skeleton/
+COPY --from=openssl /openssl /openssl
+# commented-out COPY must NOT count as shipped
+#COPY --from=paxutils /paxutils /paxutils
+
+FROM scratch AS full-image-merge-base
+COPY --from=stage2-merge /skeleton /
+COPY --from=kernel /kernel/ /skeleton/boot/
+COPY --from=pam-systemd /pam /pam
+COPY --from=libseccomp /libseccomp /libseccomp
+COPY --from=xz /xz /xz
+COPY --from=openscsi /openscsi /openscsi
+EOF
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# --- container manifest: only stage2-merge's shipped packages ---
+HADRON_ROOT="$WORK" "$GEN" --shipped "stage2-merge" --format flat \
+  --name container --out-dir "$WORK"
+
+CJSON="$WORK/container.json"
+[ -f "$CJSON" ] || fail "container.json not created"
+grep -q '"curl": "8.20.0"'    "$CJSON" || fail "container missing curl"
+grep -q '"openssl": "3.6.3"'  "$CJSON" || fail "container missing openssl"
+grep -q 'kernel'   "$CJSON" && fail "container must NOT list kernel (not shipped there)"
+grep -q 'pam'      "$CJSON" && fail "container must NOT list pam (not shipped there)"
+grep -q 'paxutils' "$CJSON" && fail "container must NOT list paxutils (its COPY is commented out)"
+
+# --- full-image manifest: union of both merge stages, -systemd suffix stripped ---
+HADRON_ROOT="$WORK" "$GEN" --shipped "stage2-merge full-image-merge-base" --format flat \
+  --name full-image --out-dir "$WORK"
+
+FJSON="$WORK/full-image.json"
+[ -f "$FJSON" ] || fail "full-image.json not created"
+grep -q '"curl": "8.20.0"'   "$FJSON" || fail "full-image missing curl"
+grep -q '"openssl": "3.6.3"' "$FJSON" || fail "full-image missing openssl"
+grep -q '"kernel": "7.1.1"'  "$FJSON" || fail "full-image missing kernel"
+grep -q '"pam": "1.7.0"'     "$FJSON" || fail "full-image missing pam (pam-systemd should map to pam)"
+# build-stage name != ARG name: aliases must bridge them
+grep -q '"seccomp": "2.6.0"'    "$FJSON" || fail "libseccomp should map to seccomp"
+grep -q '"xzutils": "5.8.3"'    "$FJSON" || fail "xz should map to xzutils"
+grep -q '"open-scsi": "2.1.11"' "$FJSON" || fail "openscsi should map to open-scsi"
+
+# --- --override sets a shipped component's version from a different ARG, keeping
+#     its on-disk name. Models the `FROM openssl-${FIPS} AS openssl` alias: in
+#     fips builds the `openssl` that ships is built from OPENSSL_FIPS_VERSION
+#     (3.1.2), not OPENSSL_VERSION (3.6.3) — one entry, named openssl. ---
+HADRON_ROOT="$WORK" "$GEN" --shipped "stage2-merge" --override "openssl=OPENSSL_FIPS_VERSION" \
+  --format flat --name ovr --out-dir "$WORK"
+
+OJSON="$WORK/ovr.json"
+[ -f "$OJSON" ] || fail "ovr.json not created"
+grep -q '"openssl": "3.1.2"' "$OJSON" || fail "--override did not set openssl to the FIPS version"
+grep -q '"openssl": "3.6.3"' "$OJSON" && fail "--override left the stale non-FIPS openssl version"
+grep -q 'openssl-fips'       "$OJSON" && fail "--override must not emit a separate openssl-fips entry"
+grep -q '"curl": "8.20.0"'   "$OJSON" || fail "--override disturbed unrelated components"
+
+# without --override, openssl keeps its default (non-fips) version
+HADRON_ROOT="$WORK" "$GEN" --shipped "stage2-merge" --format flat --name noovr --out-dir "$WORK"
+grep -q '"openssl": "3.6.3"' "$WORK/noovr.json" || fail "default openssl version should be 3.6.3"
+
+# --- flat JSON is a valid, flat object if python3 is available ---
+if command -v python3 >/dev/null 2>&1; then
+  python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert all(isinstance(v,str) for v in d.values())' "$FJSON" \
+    || fail "full-image.json is not a valid flat string map"
+fi
+
+echo "PASS: gen-components shipped/flat tests"

--- a/tests/image_structure_test.go
+++ b/tests/image_structure_test.go
@@ -26,6 +26,7 @@ package hadron_test
 //	  go run github.com/onsi/ginkgo/v2/ginkgo --label-filter image-structure ./tests/
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -130,6 +131,27 @@ var _ = Describe("hadron container image structure", Label("image-structure"), f
 		out, code := shInImage("cat /etc/os-release")
 		Expect(code).To(Equal(0), out)
 		Expect(out).To(ContainSubstring("ID=hadron"))
+	})
+
+	It("ships a parseable per-image component manifest", func() {
+		// Every shipped image carries /usr/lib/hadron/components.json: a flat
+		// { "name": "version" } map generated at build time from the
+		// Dockerfile's ARG *_VERSION defaults, filtered to what the image
+		// actually ships. See the `components` stage in the Dockerfile and
+		// hack/gen-components.sh.
+		out, code := shInImage("cat /usr/lib/hadron/components.json")
+		Expect(code).To(Equal(0),
+			"expected /usr/lib/hadron/components.json to exist; output: %s", out)
+
+		manifest := map[string]string{}
+		Expect(json.Unmarshal([]byte(out), &manifest)).To(Succeed(),
+			"components.json is not a flat string map:\n%s", out)
+		Expect(manifest).ToNot(BeEmpty(), "component manifest is empty")
+
+		// curl + openssl ship in both the minimal container and the full image.
+		Expect(manifest).To(HaveKey("curl"))
+		Expect(manifest).To(HaveKey("openssl"))
+		Expect(manifest["curl"]).ToNot(BeEmpty(), "curl version is empty")
 	})
 
 	It("ships the musl dynamic loader for the current arch", func() {


### PR DESCRIPTION
## What

Ships `/usr/lib/hadron/components.json` inside both the minimal **container** and the **full image**: a flat `{ "name": "version" }` map of the components that image actually carries — parseable by downstream consumers.

```json
{ "bash": "5.3", "curl": "8.20.0", "kernel": "7.1.1", "openssl": "3.6.3", "systemd": "261", ... }
```

Generated **at build time from the Dockerfile itself** (the `ARG *_VERSION` defaults) — single source of truth, no host or post-build step. Complements #478 (which surfaces versions in release notes / gh-pages); this puts them *in the image*.

## How

A new `components` build stage parses `ARG *_VERSION=` and intersects it with the packages each image's merge stages actually `COPY --from`, so each image gets an **accurate, per-image** list (container ≈ base set; full image adds kernel/systemd/net/storage/…). The manifest is `COPY`'d in as a **late layer**, so it only busts cache when a shipped version changes (same trick as `VERSION` injection).

It is **variant-aware**:
- `full-image-merge-${FIPS}` — fips adds `libkcapi`
- `full-image-pre-${BOOTLOADER}` — grub adds `dracut`
- fips builds `--override openssl=OPENSSL_FIPS_VERSION` — the shipped `openssl` is the `FROM openssl-${FIPS} AS openssl` alias (3.1.2, not 3.6.3)

`hack/gen-components.sh` gains `--shipped "<stages>"`, `--format flat`, and `--override "name=ARG"`. **Existing #478 generation is unchanged** (flags default off; `make components` still emits 106 components / 13 groups).

## Verification

4-variant matrix (FIPS × BOOTLOADER, cloud kernel):

| variant | entries | openssl (manifest = live) |
|---|---|---|
| nofips-grub | 54 | 3.6.3 ✓ |
| fips-grub | 55 | 3.1.2 ✓ |
| nofips-systemd | 53 | 3.6.3 ✓ |
| fips-systemd | 54 | 3.1.2 ✓ |

- Image manifest is **byte-identical** to the generator output in every variant
- 14 components cross-checked against their **live binary `--version`** — all match
- New shell test suite (`gen-components_shipped_test.sh`) + an `image-structure` Go spec asserting the manifest exists and is a valid flat map
- `make test-components` runs both shell suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)