### PR TITLE
fix: make /usr/sbin a real directory and centralize meson libdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -771,13 +771,13 @@ bin:x:1:1:bin:/dev/null:/usr/bin/false
 daemon:x:6:6:Daemon User:/dev/null:/usr/bin/false
 messagebus:x:18:18:D-Bus Message Daemon User:/run/dbus:/usr/bin/false
 uuidd:x:80:80:UUID Generation Daemon User:/dev/null:/usr/bin/false
-dbus:x:81:81:System Message Bus:/:/usr/bin/nologin
-systemd-coredump:x:980:980:systemd Core Dumper:/:/usr/bin/nologin
-systemd-network:x:979:979:systemd Network Management:/:/usr/bin/nologin
-systemd-oom:x:978:978:systemd Userspace OOM Killer:/:/usr/bin/nologin
-systemd-journal-remote:x:977:977:systemd Journal Remote:/:/usr/bin/nologin
-systemd-resolve:x:976:976:systemd Resolver:/:/usr/bin/nologin
-systemd-timesync:x:975:975:systemd Time Synchronization:/:/usr/bin/nologin
+dbus:x:81:81:System Message Bus:/:/usr/sbin/nologin
+systemd-coredump:x:980:980:systemd Core Dumper:/:/usr/sbin/nologin
+systemd-network:x:979:979:systemd Network Management:/:/usr/sbin/nologin
+systemd-oom:x:978:978:systemd Userspace OOM Killer:/:/usr/sbin/nologin
+systemd-journal-remote:x:977:977:systemd Journal Remote:/:/usr/sbin/nologin
+systemd-resolve:x:976:976:systemd Resolver:/:/usr/sbin/nologin
+systemd-timesync:x:975:975:systemd Time Synchronization:/:/usr/sbin/nologin
 nobody:x:65534:65534:Unprivileged User:/dev/null:/usr/bin/false
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -735,7 +735,7 @@ WORKDIR /sysroot
 RUN mkdir -pv {boot,home,mnt,opt,srv,tmp} \
         {etc,var} \
         etc/{opt,sysconfig} \
-        usr/{bin,lib} \
+        usr/{bin,sbin,lib} \
         usr/lib/firmware \
         usr/{,local/}{include,src} \
         usr/local/{bin,lib} \
@@ -754,8 +754,6 @@ RUN ln -sfv usr/bin sbin  # sbin -> usr/bin
 RUN ln -sfv usr/bin bin   # bin -> usr/bin
 RUN ln -sfv usr/lib lib   # lib -> usr/lib
 RUN ln -sfv usr/lib lib64 # lib64 -> usr/lib
-RUN ln -sfv bin usr/sbin  # usr/sbin -> usr/bin
-RUN ln -sfv lib usr/lib64 # usr/lib64 -> usr/lib
 RUN ln -sfv ../run var/run # var/run -> ../run important to be relative
 RUN ln -sfv ../run/lock var/lock # var/lock -> run/lock
 RUN ln -svf proc/mounts etc/mtab
@@ -1039,6 +1037,7 @@ ENV AR="gcc-ar"
 ENV NM="gcc-nm"
 ENV RANLIB="gcc-ranlib"
 ENV COMMON_CONFIGURE_ARGS="--quiet --prefix=/usr --host=${TARGET} --build=${TARGET} --enable-lto --enable-shared --disable-static"
+ENV COMMON_MESON_FLAGS="--prefix=/usr --libdir=lib --buildtype=minsize -Dstrip=true"
 # Standard aggressive size optimization flags
 ENV CFLAGS="-Os -pipe -fomit-frame-pointer -fno-unroll-loops -fno-asynchronous-unwind-tables -ffunction-sections -fdata-sections -flto=auto"
 ENV LDFLAGS="-Wl,--gc-sections -Wl,--as-needed -flto=auto"
@@ -1771,7 +1770,7 @@ WORKDIR /sources
 RUN pip3 install meson ninja
 RUN tar -xf dbus.tar.xz && mv dbus-* dbus
 WORKDIR /sources/dbus
-RUN meson setup buildDir --prefix=/usr --buildtype=minsize -Dstrip=true
+RUN meson setup buildDir ${COMMON_MESON_FLAGS}
 RUN DESTDIR=/dbus ninja -j${JOBS} -C buildDir install
 
 
@@ -1796,7 +1795,7 @@ WORKDIR /sources
 RUN tar -xf pam.tar.xz && mv Linux-PAM-* linux-pam
 WORKDIR /sources/linux-pam
 RUN pip3 install meson ninja
-RUN meson setup buildDir --prefix=/usr --buildtype=minsize -Dstrip=true
+RUN meson setup buildDir ${COMMON_MESON_FLAGS}
 RUN DESTDIR=/pam ninja -j${JOBS} -C buildDir install
 COPY files/pam/* /pam/etc/pam.d/
 
@@ -1926,7 +1925,7 @@ WORKDIR /sources
 RUN tar -xf kmod.tar.gz && mv kmod-* kmod
 WORKDIR /sources/kmod
 RUN pip3 install meson ninja
-RUN meson setup buildDir --prefix=/usr --buildtype=minsize -Dmanpages=false
+RUN meson setup buildDir ${COMMON_MESON_FLAGS} -Dmanpages=false
 RUN DESTDIR=/kmod ninja -j${JOBS} -C buildDir install && ninja -j${JOBS} -C buildDir install
 
 
@@ -2537,7 +2536,7 @@ WORKDIR /sources
 RUN tar -xf pax-utils.tar.gz && mv pax-utils-* pax-utils
 WORKDIR /sources/pax-utils
 RUN pip3 install meson ninja
-RUN meson setup buildDir --prefix=/usr --buildtype=minsize -Dstrip=true -Dtests=false -Duse_fuzzing=false
+RUN meson setup buildDir ${COMMON_MESON_FLAGS} -Dtests=false -Duse_fuzzing=false
 RUN DESTDIR=/pax-utils ninja -j${JOBS} -C buildDir install
 RUN ninja -j${JOBS} -C buildDir install
 
@@ -3229,8 +3228,7 @@ RUN python3 -m pip install meson ninja jinja2 pyelftools
 WORKDIR /sources/systemd
 
 RUN /usr/bin/meson setup buildDir \
-      --prefix=/usr           \
-      --buildtype=minsize -Dstrip=true     \
+      ${COMMON_MESON_FLAGS} \
       -D dbus=enabled  \
       -D tpm2=enabled          \
       -D pam=enabled \
@@ -3443,7 +3441,7 @@ WORKDIR /sources
 RUN pip3 install meson ninja
 RUN tar -xf dbus.tar.xz && mv dbus-* dbus
 WORKDIR /sources/dbus
-RUN meson setup buildDir --prefix=/usr --buildtype=minsize -Dstrip=true
+RUN meson setup buildDir ${COMMON_MESON_FLAGS}
 RUN DESTDIR=/dbus ninja -j${JOBS} -C buildDir install
 
 ## final build of pam with systemd support
@@ -3471,7 +3469,7 @@ WORKDIR /sources
 RUN tar -xf pam.tar.xz && mv Linux-PAM-* linux-pam
 WORKDIR /sources/linux-pam
 RUN pip3 install meson ninja
-RUN meson setup buildDir --prefix=/usr --buildtype=minsize -Dstrip=true
+RUN meson setup buildDir ${COMMON_MESON_FLAGS}
 RUN DESTDIR=/pam ninja -j${JOBS} -C buildDir install
 COPY files/pam/* /pam/etc/pam.d/
 ## We are using the pam_shells.so module in a few places, so we need a proper /etc/shells file
@@ -3558,7 +3556,7 @@ RUN mkdir -p /openscsi
 WORKDIR /sources
 RUN tar -xf openscsi.tar.gz && mv open-iscsi-* openscsi
 WORKDIR /sources/openscsi
-RUN meson setup buildDir --prefix=/usr --buildtype=minsize --optimization 3 -D isns=disabled
+RUN meson setup buildDir ${COMMON_MESON_FLAGS} --optimization 3 -D isns=disabled
 RUN DESTDIR=/openscsi ninja -j${JOBS} -C buildDir install && ninja -j${JOBS} -C buildDir install
 
 FROM rsync AS bc

--- a/Dockerfile
+++ b/Dockerfile
@@ -750,7 +750,7 @@ RUN install -dv -m 0750 root
 RUN install -dv -m 1777 var/tmp
 RUN touch etc/hostname
 
-RUN ln -sfv usr/bin sbin  # sbin -> usr/bin
+RUN ln -sfv usr/sbin sbin # sbin -> usr/sbin
 RUN ln -sfv usr/bin bin   # bin -> usr/bin
 RUN ln -sfv usr/lib lib   # lib -> usr/lib
 RUN ln -sfv usr/lib lib64 # lib64 -> usr/lib

--- a/files/systemd/sshd.service
+++ b/files/systemd/sshd.service
@@ -6,7 +6,7 @@ Wants=sshkeygen.service ssh-access.target
 
 [Service]
 Type=notify-reload
-ExecStart=/usr/bin/sshd -D
+ExecStart=/usr/sbin/sshd -D
 KillMode=process
 Restart=always
 


### PR DESCRIPTION
## Summary

- **/usr/sbin becomes a real directory** in the base image so downstream layers can `COPY --from=<layer> / /` without hitting BuildKit's `cannot copy to non-directory` symlink error. Blocks the new per-layer test stages in `kairos-io/hadron-layers` (`feat/dockerfile-test-targets`) and the documented consumer pattern from the hadron-layers README.
- **/usr/lib64 dropped entirely** — musl doesn't use it, and every meson package now installs to `/usr/lib` (see below).
- **`COMMON_MESON_FLAGS` hoisted to `stage1`** alongside `COMMON_CONFIGURE_ARGS`, with `--libdir=lib` so meson's arch-detection heuristic can't flip libdir to `lib64`. All 9 meson invocations (dbus, pam, kmod, pax-utils, systemd, dbus-systemd, pam-systemd, openscsi, glib2) now share the variable. Toolchain target re-exports it for consumer images.

## Why

BuildKit's classic `COPY` refuses to overlay a directory tree onto a path whose destination is a symlink, even when the symlink resolves to a real directory. With `/usr/sbin -> /usr/bin`, any layer that ships `/usr/sbin/*` aborts:

```
ERROR: failed to solve: cannot copy to non-directory:
/var/lib/docker/buildkit/containerd-overlayfs/cachemounts/.../usr/sbin
```

Workarounds like `COPY --link` or per-layer `mv /usr/sbin/* /usr/bin/` either silently change canonical paths or push a tax onto every layer maintainer. Fedora, Debian, openSUSE all ship merged-usr with `/usr/sbin` as a real directory; only Arch symlinks it and pays this exact cost.

While fixing `/usr/sbin`, making `/usr/lib64` a real directory triggered a latent bug: meson's libdir default flips from `lib` to `lib64` when `/usr/lib64` exists as a real directory. glib2's `.pc` files then landed in `/usr/local/lib64/pkgconfig`, which is not on pkg-config's default search path, breaking open-vm-tools' `glib2 >= 2.34.0 is required` detection. Centralizing `COMMON_MESON_FLAGS` with `--libdir=lib` prevents this regardless of layout.

## Side effects

- Binaries any package installs into `/usr/sbin` (e.g. gpg's `addgnupghome`) are reachable only via `/usr/sbin/foo`, not also `/usr/bin/foo`. `PATH` already contains `/usr/sbin` so shell + scripted use is unchanged. Anything hardcoding `/usr/bin/foo` for a genuinely-sbin binary was already broken.
- `/usr/lib64` no longer exists (was previously symlink → `/usr/lib`). Musl toolchain never used it; `COPY` into that path from a downstream layer would create it fresh with no conflict.
- Base image size delta: rounding error.

## Test plan

- [x] `make build-hadron KERNEL_TYPE=cloud` builds cleanly
- [x] `docker run --rm --entrypoint sh ghcr.io/kairos-io/hadron:main -c 'ls -la /usr/'` shows `/usr/sbin` as `drwxr-xr-x` (real dir, 91 files), `/usr/lib64` absent
- [x] `/usr/lib64` empty across meson stages — all libs land in `/usr/lib`
- [ ] hadron-layers `feat/dockerfile-test-targets` builds green (gpg / git / fwupd smoke tests) against this base
- [ ] Existing acceptance suite (kairos-agent, immucore boot flow) unaffected — nothing hardcodes `/usr/bin/foo` for sbin binaries

## References

- Discovery: `fix.yaml` spec filed from `kairos-io/hadron-layers` `feat/dockerfile-test-targets` branch
- Merged-usr background: https://www.freedesktop.org/wiki/Software/systemd/TheCaseForTheUsrMerge/