### PR TITLE
docs(components): add CVE dashboard link to footer

### DIFF
--- a/hack/components-template.html
+++ b/hack/components-template.html
@@ -253,6 +253,8 @@
     <a href="https://kairos-io.github.io/hadron-firmware/">hadron-firmware</a> and
     <a href="https://kairos-io.github.io/hadron-layers/">hadron-layers</a>.
     ·
+    <a href="https://kairos-io.github.io/security/">CVE dashboard ↗</a>
+    ·
     <a href="https://github.com/kairos-io/hadron">github.com/kairos-io/hadron</a>
   </footer>
 </div>


### PR DESCRIPTION
Link the components/firmware/layers page footer to the Kairos security CVE dashboard at https://kairos-io.github.io/security/.