### PR TITLE
fix(grub): add the sleep module to the EFI grub image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3039,7 +3039,7 @@ RUN if [ "${ARCH}" = "aarch64" ]; then \
 		-o /grub-efi/usr/lib/grub/${grub_format}/${grub_efi_name} \
 		loopback cat squash4 xzio gzio serial regexp part_gpt ext2 fat normal \
         boot configfile part_msdos linux echo search search_label search_fs_uuid \
-        search_fs_file chain loadenv gfxterm all_video iso9660 help test smbios
+        search_fs_file chain loadenv gfxterm all_video iso9660 help test smbios sleep
 
 FROM grub-base AS grub-bios
 ARG JOBS


### PR DESCRIPTION
AuroraBoot's livecd grub config uses `sleep --verbose --interruptible 30`
to give its boot-to-RAM entry a cancellable countdown. On BIOS that works
because AuroraBoot ships its own eltorito.img with the sleep module built
in, but our EFI images were built without it, so booting the same config
under EFI failed with "can't find command `sleep`" and dumped you back at
the grub prompt.

One-word fix: `sleep` added to the grub-mkimage module list in the
grub-efi Dockerfile stage, which covers grubx64.efi, grubaa64.efi and
grubriscv64.efi.