### PR TITLE
docs(riscv64): record that preset-all no longer crashes under QEMU

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -3811,9 +3811,14 @@ FROM scratch AS full-image-systemd
 COPY --from=full-image-pre-systemd /skeleton /
 
 ## Final image depending on the bootloader
-# Split before systemctl preset-all: QEMU cannot run that step reliably (SIGSEGV).
-# CI builds full-image-pre-preset on x86, pushes OCI, then native riscv64 imports it
+# Split before systemctl preset-all: it was unreliable under QEMU (SIGSEGV), so CI
+# builds full-image-pre-preset on x86, pushes OCI, then native riscv64 imports it
 # via buildx --build-context full-image-pre-preset=docker-image://… for full-image-final.
+#
+# Retested 2026-08-13 with qemu-user 10.2.2: preset-all completed on 21/21 emulated
+# riscv64 runs (~0.9s each) and the whole `default` target built green under emulation.
+# The split is kept until CI is re-timed on stock runners, but the QEMU failure that
+# motivated it (8855153, ca32df5) no longer reproduces on a current QEMU.
 FROM full-image-${BOOTLOADER} AS full-image-pre-preset
 SHELL ["/bin/bash", "-c"]
 ARG VERSION
@@ -3875,7 +3880,8 @@ FROM full-image-pre-preset AS full-image-final
 SHELL ["/bin/bash", "-c"]
 ARG VERSION
 ARG BUILD_ARCH
-# preset all systemd services (native riscv64 in CI; crashes under QEMU)
+# preset all systemd services (runs natively on riscv64 in CI; see the note on
+# full-image-pre-preset — the QEMU crash no longer reproduces on qemu-user 10.2.2)
 RUN systemctl preset-all
 # Disable systemd-make-policy as we don't use it and it conflicts with
 # measurements with PCR policies


### PR DESCRIPTION
## What

Updates two comments around `systemctl preset-all` in `Dockerfile.tmpl`. **Comments only — no behaviour change**, and the pipeline split stays exactly as it is.

## Why

The comments currently assert that QEMU "cannot run that step reliably (SIGSEGV)". That is why `full-image-pre-preset` and `full-image-final` are split, and why `hadron-bios-riscv64` is the only job in the matrix pinned to `ubuntu-24.04-riscv`.

That no longer reproduces on a current QEMU. Tested against this commit with **zero code changes**:

- the full `default` target built green under riscv64 emulation on x86 — 1473/1473 steps
- `systemctl preset-all` **executed** rather than hitting cache (real output, not a `CACHED` line)
- 20 further runs with the stage cache forced off (`--no-cache-filter full-image-final`): **21/21 green in total, flat ~0.9s each**

The repeats are the point: [`8855153`](https://github.com/kairos-io/hadron/commit/8855153) describes an *intermittent* failure, and a single green build cannot refute that.

Environment: `qemu-user-static` **10.2.2**, `binfmt_misc` `qemu-riscv64` with flag `F`. For comparison, `tonistiigi/binfmt:latest` — what `docker/setup-qemu-action` installs — currently ships qemu **v10.2.1**.

## What this PR deliberately does not do

It does **not** claim the split is unnecessary, and does not touch the workflow. Removing the split needs numbers this PR does not have:

- the cold nine-stage chain took **20h13m** locally; the workflow's own comment estimates ~30–40 min warm for `full-image-pre-preset`. CI has not been re-timed on stock runners.
- only one config was exercised (`BOOTLOADER=grub`, `KERNEL_TYPE=cloud` — matching `hadron-bios-riscv64`), not the full matrix.
- QEMU was not bisected, so the *minimum* working version is unknown. If the split is ever removed, CI should pin the binfmt image rather than inherit a default.

So this just stops the comments asserting a constraint that does not reproduce, and points at the origin commits ([`8855153`](https://github.com/kairos-io/hadron/commit/8855153), [`ca32df5`](https://github.com/kairos-io/hadron/commit/ca32df5)) so the next person re-checks rather than inheriting it as settled fact.

## Note

`Dockerfile` is generated from `Dockerfile.tmpl` by `hack/render.sh` and is gitignored, so only the template is changed here. The renderer was run to confirm the change propagates cleanly and produces no other tracked diff.
