### PR TITLE
test: cover the extension install on a non-UKI recovery boot

### DIFF
--- a/.github/workflows/PR_multiarch.yml
+++ b/.github/workflows/PR_multiarch.yml
@@ -573,6 +573,28 @@ jobs:
             VERSION=v0.0.1-${{ github.sha }}
             TRUSTED_BOOT=false
             FIPS=${{ matrix.fips }}
+      # The recovery test needs an extension inside the image. /var/lib/kairos
+      # is an ephemeral overlay, not persistent, so a file written at runtime
+      # does not survive a reboot and is not visible to another boot mode. The
+      # UKI path uses --overlay-iso for this; the BIOS path has no equivalent,
+      # so the fixture goes in as a layer here.
+      - name: Add the recovery extension fixture
+        run: |
+          cat > build/Dockerfile.sysext <<'DOCKERFILE'
+          ARG SOURCE_IMAGE
+          FROM ${SOURCE_IMAGE}
+          COPY tests/assets/sysext/work.sysext.raw /var/lib/kairos/extensions/recovery/work.sysext.raw
+          DOCKERFILE
+          IMAGE=ttl.sh/hadron-init-bios${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64:${{ github.sha }}
+          docker buildx build \
+            --builder ${{ steps.buildx.outputs.name }} \
+            --build-arg SOURCE_IMAGE="${IMAGE}" \
+            --file build/Dockerfile.sysext \
+            --platform linux/amd64 \
+            --provenance false \
+            --push \
+            --tag "${IMAGE}" \
+            .
 
   build-kairos-trusted-amd64:
     runs-on: ubuntu-latest
@@ -676,6 +698,7 @@ jobs:
           - "acceptance"
           - "reset"
           - "custom-partitioning"
+          - "recovery"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/PR_multiarch.yml
+++ b/.github/workflows/PR_multiarch.yml
@@ -580,21 +580,25 @@ jobs:
       # so the fixture goes in as a layer here.
       - name: Add the recovery extension fixture
         run: |
-          cat > build/Dockerfile.sysext <<'DOCKERFILE'
+          # The repository .dockerignore excludes tests/, so the fixture cannot
+          # be COPYed from a build context rooted at the repository. It is
+          # staged into its own small context instead. Relaxing .dockerignore
+          # would pull test files into every hadron image build.
+          mkdir -p build/sysext-ctx
+          cp tests/assets/sysext/work.sysext.raw build/sysext-ctx/
+          cat > build/sysext-ctx/Dockerfile <<'DOCKERFILE'
           ARG SOURCE_IMAGE
           FROM ${SOURCE_IMAGE}
-          COPY tests/assets/sysext/work.sysext.raw /var/lib/kairos/extensions/recovery/work.sysext.raw
+          COPY work.sysext.raw /var/lib/kairos/extensions/recovery/work.sysext.raw
           DOCKERFILE
           IMAGE=ttl.sh/hadron-init-bios${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64:${{ github.sha }}
-          docker buildx build \
+          docker buildx build build/sysext-ctx \
             --builder ${{ steps.buildx.outputs.name }} \
             --build-arg SOURCE_IMAGE="${IMAGE}" \
-            --file build/Dockerfile.sysext \
             --platform linux/amd64 \
             --provenance false \
             --push \
-            --tag "${IMAGE}" \
-            .
+            --tag "${IMAGE}"
 
   build-kairos-trusted-amd64:
     runs-on: ubuntu-latest

--- a/tests/acceptance_test.go
+++ b/tests/acceptance_test.go
@@ -293,4 +293,37 @@ openssl x509 -in /etc/ssl/certs/ca-cert-hadron-custom-ca.pem -noout -subject`)
 				ContainSubstring("ok"),
 			))
 	})
+	// immucore picks the extension source directory from the boot state. Until
+	// kairos-io/immucore#613 that switch had no AutoReset arm, so a state reset
+	// installed no extensions and only logged it at debug level. Nothing caught
+	// it, because the only extension test is the UKI one and this path is not
+	// UKI. This covers the recovery arm, which AutoReset shares.
+	//
+	// The fixture lives at /var/lib/kairos/extensions/recovery/ inside the
+	// image. The workflow puts it there, because /var/lib/kairos is an
+	// ephemeral overlay and a file written from the active boot would not
+	// survive the reboot.
+	It("installs the recovery extensions", Label("recovery"), func() {
+		installAndBootToActive()
+
+		By("Setting the next entry to recovery")
+		_, err := vm.Sudo("grub2-editenv /oem/grubenv set next_entry=recovery")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Rebooting")
+		vm.Reboot()
+
+		By("Checking that vm has rebooted to 'recovery'")
+		Eventually(func() string {
+			out, _ := vm.Sudo("kairos-agent state boot")
+			return out
+		}, 40*time.Minute, 10*time.Second).Should(
+			ContainSubstring("recovery_boot"))
+
+		By("Checking the extension was copied during the recovery boot", func() {
+			out, err := vm.Sudo("ls /run/extensions")
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("work.sysext.raw"))
+		})
+	})
 })


### PR DESCRIPTION
Option A from [kairos-io/kairos#4321](https://github.com/kairos-io/kairos/issues/4321).

## Why

`immucore` picks the extension source directory from the boot state. Until [kairos-io/immucore#613](https://github.com/kairos-io/immucore/pull/613) that switch had no `state.AutoReset` arm, so **a state reset installed no system extensions and no configuration extensions** — and logged it at `Debug` level only. Every test stayed green.

Nothing caught it, because the only extension test here is the UKI one and this path is not UKI. **The non-UKI extension install has no coverage today, in any boot mode.**

## What this adds

A `recovery` spec: boot `next_entry=recovery`, then assert `work.sysext.raw` reached `/run/extensions` while still in that boot. That is the `case state.Recovery, state.AutoReset:` arm, tested through its recovery half.

## Why the fixture goes in at image build time

This is the part worth reviewing. `/var/lib/kairos` is **not** persistent — `RW_PATHS` become ephemeral overlays in immucore, and `PERSISTENT_STATE_PATHS` is the separate persistent list. immucore says so itself:

> Skipping ephemeral overlay: path is not in the OS image. Writes to it will fail against the read-only rootfs. Create the directory at image build time or drop it from ephemeral_mounts/RW_PATHS.

So a fixture written from the active boot does not survive the reboot and is not visible to the recovery boot. It has to be in the image.

The UKI path solves this with `--overlay-iso`. The BIOS path has no equivalent, so this layers the fixture onto `hadron-init-bios*-amd64` in `build-kairos-bios-amd64`. It lands under `extensions/recovery/`, so only a recovery-state boot reads it and the other tests are unaffected.

**If there is a cleaner injection point in this build, I would rather use it.** That is the open question from #4321 and the reason this is a draft.

## What is verified, and what is not

Verified locally:

```
go vet ./tests/...                clean
PR_multiarch.yml parses           20 jobs
matrix                            acceptance, reset, custom-partitioning, recovery
--label-filter "recovery"         matches Label("recovery")
```

**Not verified: the test has never run.** It needs the VM matrix. Two assumptions the CI run will settle, and both would show up as a failure in this spec alone:

1. The BIOS recovery boot is reachable over SSH. The UKI recovery test does this, so I expect it, but I have not confirmed it for BIOS.
2. Layering onto the same `ttl.sh` tag behaves. If it does not, building to a distinct tag and pointing the ISO build at it is the fallback.

## Scope

`immucore#613` fixed the bug and [`immucore#614`](https://github.com/kairos-io/immucore/pull/614) makes the `exhaustive` linter catch a *missing* case in any switch over `state.Boot`. This catches a *wrong* one, which the linter cannot, and closes the untested non-UKI path on its own merits.

---

AI assisted this pull request. A human is attending and directed it.
