### PR TITLE
ci: hand the arm64 images between jobs as tarballs, not via ttl.sh

### DIFF
--- a/.github/workflows/PR_multiarch.yml
+++ b/.github/workflows/PR_multiarch.yml
@@ -162,7 +162,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           platforms: linux/arm64
-          tags: ttl.sh/hadron-toolchain-arm64:${{ github.sha }}
+          tags: hadron-toolchain-arm64:${{ github.sha }}
           labels: |
             ${{ steps.meta.outputs.labels }}
           target: toolchain
@@ -299,7 +299,7 @@ jobs:
           # load into the local docker image store so the structure tests below
           # can `docker run` it without a registry round-trip.
           load: true
-          tags: ttl.sh/hadron-container-arm64:${{ github.sha }}
+          tags: hadron-container-arm64:${{ github.sha }}
           labels: |
             ${{ steps.meta.outputs.labels }}
           target: container
@@ -337,7 +337,7 @@ jobs:
       - name: Run image-structure tests
         env:
           # Image was loaded locally by the build step above (no push needed).
-          CONTAINER_IMAGE: ttl.sh/hadron-container-arm64:${{ github.sha }}
+          CONTAINER_IMAGE: hadron-container-arm64:${{ github.sha }}
         run: |
           cp tests/go.* .
           go mod download
@@ -899,8 +899,11 @@ jobs:
           context: ./
           file: ./Dockerfile
           platforms: linux/arm64
-          push: true
-          tags: ttl.sh/hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-arm64:${{ github.sha }}
+          # Loaded into the local image store and handed to the next job as a
+          # tarball artifact. No registry is involved, so this works on a pull
+          # request from a fork, which has no secrets.
+          load: true
+          tags: hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-arm64:${{ github.sha }}
           labels: |
             ${{ steps.meta.outputs.labels }}
           target: default
@@ -918,6 +921,19 @@ jobs:
             ARCH=aarch64
             BUILD_ARCH=aarch64
 
+      - name: Save the image as a tarball
+        run: |
+          docker save hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-arm64:${{ github.sha }} | gzip > hadron-arm64.tar.gz
+      - name: Upload the image
+        uses: actions/upload-artifact@v7
+        with:
+          name: hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-arm64-image
+          path: hadron-arm64.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          # already gzipped
+          compression-level: 0
+
   build-kairos-grub-arm64:
     runs-on: ubuntu-24.04-arm
     needs:
@@ -927,28 +943,43 @@ jobs:
         uses: actions/checkout@v7
       - name: Render Dockerfile
         uses: ./.github/actions/render-dockerfile
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@master
+      - name: Download the image
+        uses: actions/download-artifact@v8
+        with:
+          name: hadron-cloud-arm64-image
+      - name: Load the image
+        run: |
+          gunzip -c hadron-arm64.tar.gz | docker load
       - name: Download Dockerfile from kairos repository
         run: |
           mkdir -p build
           curl -sSL https://raw.githubusercontent.com/kairos-io/kairos/master/images/Dockerfile -o build/Dockerfile.kairos
-      - name: Build and push
-        uses: docker/build-push-action@v7
+      # Plain docker build, not buildx. The buildx docker-container driver
+      # cannot resolve a FROM against the local image store, and the base image
+      # arrives here as a tarball rather than from a registry. This job is a
+      # native arm64 build with no cache export, so it needs nothing buildx adds.
+      - name: Build the kairos image
         env:
           SOURCE_DATE_EPOCH: 0
+        run: |
+          docker build ./ \
+            --file ./build/Dockerfile.kairos \
+            --tag hadron-init-bios-arm64:${{ github.sha }} \
+            --build-arg BASE_IMAGE=hadron-cloud-arm64:${{ github.sha }} \
+            --build-arg VERSION=v0.0.1-${{ github.sha }} \
+            --build-arg TRUSTED_BOOT=false
+      - name: Save the image as a tarball
+        run: |
+          docker save hadron-init-bios-arm64:${{ github.sha }} | gzip > hadron-init-bios-arm64.tar.gz
+      - name: Upload the image
+        uses: actions/upload-artifact@v7
         with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: ./
-          file: ./build/Dockerfile.kairos
-          push: true
-          platforms: linux/arm64
-          tags: ttl.sh/hadron-init-bios-arm64:${{ github.sha }}
-          build-args: |
-            BASE_IMAGE=ttl.sh/hadron-cloud-arm64:${{ github.sha }}
-            VERSION=v0.0.1-${{ github.sha }}
-            TRUSTED_BOOT=false
+          name: hadron-init-bios-arm64-image
+          path: hadron-init-bios-arm64.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          # already gzipped
+          compression-level: 0
 
   build-grub-iso-arm64:
     runs-on: ubuntu-24.04-arm
@@ -957,9 +988,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@master
+      - name: Download the image
+        uses: actions/download-artifact@v8
+        with:
+          name: hadron-init-bios-arm64-image
+      - name: Load the image
+        run: |
+          gunzip -c hadron-init-bios-arm64.tar.gz | docker load
+      # AuroraBoot mounts the docker socket, so it resolves docker:<name> from
+      # the local image store that the load step above populated.
       - name: Build ISO
         run: |
           mkdir build
@@ -967,7 +1004,7 @@ jobs:
           -v $PWD/build/:/output \
           quay.io/kairos/auroraboot:v0.21.0-alpha.4 --debug build-iso --output /output/ \
           --override-name kairos-hadron-bios-${{ github.sha }} \
-          docker:ttl.sh/hadron-init-bios-arm64:${{ github.sha }}
+          docker:hadron-init-bios-arm64:${{ github.sha }}
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
First step of moving off `ttl.sh`. Scoped to the **arm64 chain only** so the shape can be reviewed and proven before the amd64 and trusted chains follow.

## Why

`ttl.sh` returned **502 Bad Gateway** during the `kairos-init` `v0.17.1` release today. buildx retried for 33 minutes and gave up, twice in a row:

```
ERROR: failed to push ttl.sh/kairos:f21edc17...-amd64:
  unexpected status from HEAD request to https://ttl.sh/v2/kairos/blobs/sha256:...: 502 Bad Gateway
```

It is a free service with no SLA, sitting on the critical path of the build.

## Why an artifact rather than a credentialed registry

GitHub does not pass repository secrets to a `pull_request` run from a fork. So **any authenticated registry takes CI away from external contributors** — that is the one property `ttl.sh` was buying us. A tarball artifact keeps it, and needs no credentials, no external service, and no cleanup policy.

## What actually changed

The arm64 chain has **two real handoffs**:

| from | to | image |
|---|---|---|
| `hadron-grub-arm64` | `build-kairos-grub-arm64` | the full hadron image |
| `build-kairos-grub-arm64` | `build-grub-iso-arm64` | the kairos-init image |

Both now go through `docker save \| gzip` → artifact → `docker load`. AuroraBoot already mounts the docker socket, so it resolves `docker:<name>` straight from the local image store.

**Two other `ttl.sh` names in this chain were never pushed at all.** `toolchain-arm64` sets a tag and neither pushes nor loads it — the real handoff there is the buildx registry cache. `container-arm64` uses `load: true` and consumes the image in the same job. Both are renamed to plain local names so nothing implies a registry that was never involved.

`build-kairos-grub-arm64` now uses plain `docker build`. The buildx `docker-container` driver cannot resolve a `FROM` against the local image store, and this job is a native arm64 build with no cache export — it needs nothing buildx adds.

## A hazard this removes

The workflow carried this comment:

> `ttl.sh` tags must not match the amd64 jobs in this workflow: both trigger on the same `github.sha`, so last-writer wins would cause amd64 BIOS jobs to silently pull `linux/arm64`.

Artifacts are scoped per job, so that collision is structurally impossible now.

## Scope and what is untouched

The amd64 and trusted chains still use `ttl.sh` — 17 references remain in this file, deliberately. The build cache on `quay.io/kairos/hadron-build-cache` is untouched; it is already credential-guarded by `PR_CACHE_WRITE` and degrades cleanly without secrets.

`PR_riscv64.yml`'s 6 references are dead code — every job in it is `if: ${{ false }}`.

## What is verified, and what is not

Verified: the YAML parses with all 20 jobs intact, every producer artifact name matches its consumer, and no `ttl.sh` reference remains anywhere in the five arm64 jobs.

**Not verified: this has never run.** The CI on this pull request is the check. Two things to watch, and both fail loudly rather than silently:

1. **Artifact size.** Published `hadron:v0.5.1` arm64 is small, but `docker save` output is uncompressed before the gzip pipe. If it is unexpectedly large this will show as slow upload steps.
2. **`load: true` on `hadron-grub-arm64`.** `container-arm64` already does exactly this on the same runner and builder, so I expect it to work.

One thing worth a reviewer's eye: `hadron-grub-arm64`'s matrix is `kernel: ["cloud"]`, so the producer artifact name interpolates to `hadron-cloud-arm64-image` and the consumer hardcodes that. If a second kernel is ever added to that matrix, the consumer needs to select which one it wants.

---

AI assisted this pull request. A human is attending and directed it.
