### PR TITLE
ci: move the amd64 and trusted build chains off ttl.sh

### DIFF
--- a/.github/scripts/image-size-report.sh
+++ b/.github/scripts/image-size-report.sh
@@ -43,14 +43,16 @@ NEGLIGIBLE_PCT="${NEGLIGIBLE_PCT:-0.1}"         # 0.10%
 FILE_MIN_DELTA="${FILE_MIN_DELTA:-4096}"        # 4 KiB
 
 # Build the per-variant comparison table from the shared SIZE_VARIANTS list:
-#   name | PR image (this build, pushed to ttl.sh) | main baseline (ghcr.io)
+#   name | PR image (this build, already docker-loaded locally by the workflow
+#         from a tarball artifact — see the image-size-report-amd64 job) |
+#         main baseline (ghcr.io)
 # PR bios tags carry a -amd64 suffix; trusted tags do not (see PR_multiarch.yml).
 VARIANTS=()
 for _v in "${SIZE_VARIANTS[@]}"; do
   _name="${_v%%|*}"
   case "$_name" in
-  *-trusted) _pr="ttl.sh/${_name}-${SHA}:24h" ;;    # trusted tags: SHA in name, TTL as tag
-    *)         _pr="ttl.sh/${_name}-amd64:${SHA}" ;;  # bios tags: -amd64 suffix
+  *-trusted) _pr="${_name}-${SHA}:24h" ;;    # trusted tags: SHA in name, TTL as tag
+    *)         _pr="${_name}-amd64:${SHA}" ;;  # bios tags: -amd64 suffix
   esac
   _main="$(size_variant_ghcr "$REPO" "$_name")"
   VARIANTS+=("${_name}|${_pr}|${_main}")
@@ -109,10 +111,11 @@ for v in "${VARIANTS[@]}"; do
   fi
   main_sz=$(docker image inspect "$main_img" --format '{{.Size}}')
 
-  # PR image must exist since this job runs after the build jobs succeed. If it
-  # is somehow missing (e.g. push silently failed or tag expired), skip rather
-  # than aborting the whole report with no output.
-  if ! docker pull -q "$pr_img" >/dev/null 2>&1; then
+  # PR image was docker-loaded locally by the workflow before this script
+  # runs (see image-size-report-amd64 in PR_multiarch.yml), so this checks
+  # local presence rather than pulling. Skip rather than aborting the whole
+  # report with no output if it is somehow missing (e.g. a build job failed).
+  if ! docker image inspect "$pr_img" >/dev/null 2>&1; then
     summary_rows+="| \`${name}\` | $(human "$main_sz") | _PR image not found_ | — |"$'\n'
     continue
   fi

--- a/.github/workflows/PR_multiarch.yml
+++ b/.github/workflows/PR_multiarch.yml
@@ -116,7 +116,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           platforms: linux/amd64
-          tags: ttl.sh/hadron-toolchain-amd64:${{ github.sha }}
+          tags: hadron-toolchain-amd64:${{ github.sha }}
           labels: |
             ${{ steps.meta.outputs.labels }}
             cache-label=quay-remote-amd64
@@ -218,7 +218,7 @@ jobs:
           # load into the local docker image store so the structure tests below
           # can `docker run` it without a registry round-trip.
           load: true
-          tags: ttl.sh/hadron-container-amd64:${{ github.sha }}
+          tags: hadron-container-amd64:${{ github.sha }}
           labels: |
             ${{ steps.meta.outputs.labels }}
             cache-label=quay-remote-amd64
@@ -253,7 +253,7 @@ jobs:
       - name: Run image-structure tests
         env:
           # Image was loaded locally by the build step above (no push needed).
-          CONTAINER_IMAGE: ttl.sh/hadron-container-amd64:${{ github.sha }}
+          CONTAINER_IMAGE: hadron-container-amd64:${{ github.sha }}
         run: |
           cp tests/go.* .
           go mod download
@@ -393,11 +393,13 @@ jobs:
           context: ./
           file: ./Dockerfile
           platforms: linux/amd64
-          push: true
-          # Keep ephemeral ttl.sh indexes simple; the arm64 pipeline in this workflow uses separate *-arm64 tags
-          # so this tag is not clobbered by the arm64 jobs (same github.sha).
+          # Loaded into the local image store and handed to the consuming jobs
+          # (build-kairos-bios-amd64, image-size-report-amd64) as a tarball
+          # artifact. No registry is involved, so this works on a pull request
+          # from a fork, which has no secrets.
+          load: true
           provenance: false
-          tags: ttl.sh/hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64:${{ github.sha }}
+          tags: hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           target: default
           cache-from: |
@@ -412,6 +414,22 @@ jobs:
             BOOTLOADER=grub
             KERNEL_TYPE=${{ matrix.kernel }}
             FIPS=${{ matrix.fips }}
+      - name: Save the image as a tarball
+        # The file name carries the variant: this artifact and its siblings
+        # (other kernel/fips combos) are all downloaded into one workspace by
+        # image-size-report-amd64, so a shared file name would silently
+        # overwrite the earlier download.
+        run: |
+          docker save hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64:${{ github.sha }} | gzip > hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64.tar.gz
+      - name: Upload the image
+        uses: actions/upload-artifact@v7
+        with:
+          name: hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64-image
+          path: hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          # already gzipped
+          compression-level: 0
 
   hadron-trusted-amd64:
     runs-on: oracle-vm-32cpu-128gb-x86-64
@@ -456,9 +474,13 @@ jobs:
           context: ./
           file: ./Dockerfile
           platforms: linux/amd64
-          push: true
+          # Loaded into the local image store and handed to the consuming jobs
+          # (build-kairos-trusted-amd64, image-size-report-amd64) as a tarball
+          # artifact. No registry is involved, so this works on a pull request
+          # from a fork, which has no secrets.
+          load: true
           provenance: false
-          tags: ttl.sh/hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-trusted-${{ github.sha }}:24h
+          tags: hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-trusted-${{ github.sha }}:24h
           labels: ${{ steps.meta.outputs.labels }}
           target: default
           cache-from: |
@@ -472,6 +494,20 @@ jobs:
           build-args: |
             BOOTLOADER=systemd
             KERNEL_TYPE=${{ matrix.kernel }}
+      - name: Save the image as a tarball
+        # The file name carries the variant, for the same reason as
+        # hadron-bios-amd64's save step above.
+        run: |
+          docker save hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-trusted-${{ github.sha }}:24h | gzip > hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-trusted.tar.gz
+      - name: Upload the image
+        uses: actions/upload-artifact@v7
+        with:
+          name: hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-trusted-image
+          path: hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-trusted.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          # already gzipped
+          compression-level: 0
 
   component-versions-report-amd64:
     # Informational only: posts a single sticky PR comment with a collapsed
@@ -520,10 +556,10 @@ jobs:
             printf '## 🧩 Component versions (amd64)\n\n'
 
             for variant in \
-              "container|ttl.sh/hadron-container-amd64:${SHA}|container (stage2-merge)" \
-              "full-image-bios-no-fips|ttl.sh/hadron-cloud-amd64:${SHA}|bios / no-fips" \
-              "full-image-bios-fips|ttl.sh/hadron-cloud-fips-amd64:${SHA}|bios / fips" \
-              "full-image-trusted|ttl.sh/hadron-cloud-trusted-${SHA}:24h|trusted (systemd / no-fips)"
+              "container|hadron-container-amd64:${SHA}|container (stage2-merge)" \
+              "full-image-bios-no-fips|hadron-cloud-amd64:${SHA}|bios / no-fips" \
+              "full-image-bios-fips|hadron-cloud-fips-amd64:${SHA}|bios / fips" \
+              "full-image-trusted|hadron-cloud-trusted-${SHA}:24h|trusted (systemd / no-fips)"
             do
               name="${variant%%|*}"; rest="${variant#*|}"
               image="${rest%%|*}"; label="${rest#*|}"
@@ -552,30 +588,31 @@ jobs:
         uses: actions/checkout@v7
       - name: Render Dockerfile
         uses: ./.github/actions/render-dockerfile
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@master
+      - name: Download the image
+        uses: actions/download-artifact@v8
+        with:
+          name: hadron-cloud${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64-image
+      - name: Load the image
+        run: |
+          gunzip -c hadron-cloud${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64.tar.gz | docker load
       - name: Download Dockerfile from kairos repository
         run: |
           mkdir -p build
           curl -sSL https://raw.githubusercontent.com/kairos-io/kairos/${{ env.KAIROS_DOCKERFILE_REF }}/images/Dockerfile -o build/Dockerfile.kairos
-      - name: Build and push
-        uses: docker/build-push-action@v7
+      # Plain docker build, not buildx. The buildx docker-container driver
+      # cannot resolve a FROM against the local image store, and the base image
+      # arrives here as a tarball rather than from a registry.
+      - name: Build the kairos image
         env:
           SOURCE_DATE_EPOCH: 0
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: ./
-          file: ./build/Dockerfile.kairos
-          platforms: linux/amd64
-          push: true
-          provenance: false
-          tags: ttl.sh/hadron-init-bios${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64:${{ github.sha }}
-          build-args: |
-            BASE_IMAGE=ttl.sh/hadron-cloud${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64:${{ github.sha }}
-            VERSION=v0.0.1-${{ github.sha }}
-            TRUSTED_BOOT=false
-            FIPS=${{ matrix.fips }}
+        run: |
+          docker build ./ \
+            --file ./build/Dockerfile.kairos \
+            --tag hadron-init-bios${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64:${{ github.sha }} \
+            --build-arg BASE_IMAGE=hadron-cloud${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64:${{ github.sha }} \
+            --build-arg VERSION=v0.0.1-${{ github.sha }} \
+            --build-arg TRUSTED_BOOT=false \
+            --build-arg FIPS=${{ matrix.fips }}
       # The recovery test needs an extension inside the image. /var/lib/kairos
       # is an ephemeral overlay, not persistent, so a file written at runtime
       # does not survive a reboot and is not visible to another boot mode. The
@@ -594,14 +631,22 @@ jobs:
           FROM ${SOURCE_IMAGE}
           COPY work.sysext.raw /var/lib/kairos/extensions/recovery/work.sysext.raw
           DOCKERFILE
-          IMAGE=ttl.sh/hadron-init-bios${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64:${{ github.sha }}
-          docker buildx build build/sysext-ctx \
-            --builder ${{ steps.buildx.outputs.name }} \
+          IMAGE=hadron-init-bios${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64:${{ github.sha }}
+          docker build build/sysext-ctx \
             --build-arg SOURCE_IMAGE="${IMAGE}" \
-            --platform linux/amd64 \
-            --provenance false \
-            --push \
             --tag "${IMAGE}"
+      - name: Save the image as a tarball
+        run: |
+          docker save hadron-init-bios${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64:${{ github.sha }} | gzip > hadron-init-bios-amd64.tar.gz
+      - name: Upload the image
+        uses: actions/upload-artifact@v7
+        with:
+          name: hadron-init-bios${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64-image
+          path: hadron-init-bios-amd64.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          # already gzipped
+          compression-level: 0
 
   build-kairos-trusted-amd64:
     runs-on: ubuntu-latest
@@ -612,29 +657,42 @@ jobs:
         uses: actions/checkout@v7
       - name: Render Dockerfile
         uses: ./.github/actions/render-dockerfile
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@master
+      - name: Download the image
+        uses: actions/download-artifact@v8
+        with:
+          name: hadron-cloud-trusted-image
+      - name: Load the image
+        run: |
+          gunzip -c hadron-cloud-trusted.tar.gz | docker load
       - name: Download Dockerfile from kairos repository
         run: |
           mkdir -p build
           curl -sSL https://raw.githubusercontent.com/kairos-io/kairos/${{ env.KAIROS_DOCKERFILE_REF }}/images/Dockerfile -o build/Dockerfile.kairos
-      - name: Build and push
-        uses: docker/build-push-action@v7
+      # Plain docker build, not buildx. The buildx docker-container driver
+      # cannot resolve a FROM against the local image store, and the base image
+      # arrives here as a tarball rather than from a registry.
+      - name: Build the kairos image
         env:
           SOURCE_DATE_EPOCH: 0
+        run: |
+          docker build ./ \
+            --file ./build/Dockerfile.kairos \
+            --tag hadron-init-trusted:${{ github.sha }} \
+            --build-arg BASE_IMAGE=hadron-cloud-trusted-${{ github.sha }}:24h \
+            --build-arg VERSION=v0.0.1-${{ github.sha }} \
+            --build-arg TRUSTED_BOOT=true
+      - name: Save the image as a tarball
+        run: |
+          docker save hadron-init-trusted:${{ github.sha }} | gzip > hadron-init-trusted.tar.gz
+      - name: Upload the image
+        uses: actions/upload-artifact@v7
         with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: ./
-          file: ./build/Dockerfile.kairos
-          push: true
-          platforms: linux/amd64
-          provenance: false
-          tags: ttl.sh/hadron-init-trusted:${{ github.sha }}
-          build-args: |
-            BASE_IMAGE=ttl.sh/hadron-cloud-trusted-${{ github.sha }}:24h
-            VERSION=v0.0.1-${{ github.sha }}
-            TRUSTED_BOOT=true
+          name: hadron-init-trusted-image
+          path: hadron-init-trusted.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          # already gzipped
+          compression-level: 0
 
   build-bios-iso-amd64:
     runs-on: ubuntu-latest
@@ -649,6 +707,15 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
+      - name: Download the image
+        uses: actions/download-artifact@v8
+        with:
+          name: hadron-init-bios${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64-image
+      - name: Load the image
+        run: |
+          gunzip -c hadron-init-bios-amd64.tar.gz | docker load
+      # AuroraBoot mounts the docker socket, so it resolves docker:<name> from
+      # the local image store that the load step above populated.
       - name: Build ISO
         run: |
           mkdir build
@@ -656,7 +723,7 @@ jobs:
           -v $PWD/build/:/output \
           quay.io/kairos/auroraboot:v0.21.0-alpha.4 --debug build-iso --output /output/ \
           --override-name kairos-hadron-bios${{ matrix.fips == 'fips' && '-fips' || '' }}-${{ github.sha }} \
-          docker:ttl.sh/hadron-init-bios${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64:${{ github.sha }}
+          docker:hadron-init-bios${{ matrix.fips == 'fips' && '-fips' || '' }}-amd64:${{ github.sha }}
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
@@ -673,6 +740,15 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
+      - name: Download the image
+        uses: actions/download-artifact@v8
+        with:
+          name: hadron-init-trusted-image
+      - name: Load the image
+        run: |
+          gunzip -c hadron-init-trusted.tar.gz | docker load
+      # AuroraBoot mounts the docker socket, so it resolves docker:<name> from
+      # the local image store that the load step above populated.
       - name: Build ISO
         run: | # when agent has fixed the bootentry selection, we can add --sdboot-in-source to use the bundled sdboot
           mkdir build
@@ -687,7 +763,7 @@ jobs:
           --sb-cert /keys/db.pem \
           --output-type iso \
           --overlay-iso /overlay \
-          docker:ttl.sh/hadron-init-trusted:${{ github.sha }}
+          docker:hadron-init-trusted:${{ github.sha }}
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
@@ -872,6 +948,35 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # The four PR image variants this report compares against :main all
+      # arrive as tarball artifacts now, not a ttl.sh pull. Each producer job
+      # gave its tarball a variant-specific file name, so all four can be
+      # downloaded into this one workspace without clobbering each other.
+      # Named individually rather than by glob/pattern: hadron-bios-amd64 also
+      # produces a hadron-cloud-fips-amd64-image artifact this report does not
+      # use, and a broad pattern risks picking up the (differently named)
+      # hadron-init-*-image artifacts from the build-kairos-*-amd64 jobs too.
+      - name: Download hadron-amd64-image
+        uses: actions/download-artifact@v8
+        with:
+          name: hadron-amd64-image
+      - name: Download hadron-cloud-amd64-image
+        uses: actions/download-artifact@v8
+        with:
+          name: hadron-cloud-amd64-image
+      - name: Download hadron-trusted-image
+        uses: actions/download-artifact@v8
+        with:
+          name: hadron-trusted-image
+      - name: Download hadron-cloud-trusted-image
+        uses: actions/download-artifact@v8
+        with:
+          name: hadron-cloud-trusted-image
+      - name: Load the images
+        run: |
+          for f in hadron-amd64.tar.gz hadron-cloud-amd64.tar.gz hadron-trusted.tar.gz hadron-cloud-trusted.tar.gz; do
+            gunzip -c "$f" | docker load
+          done
       - name: Generate size report
         run: |
           .github/scripts/image-size-report.sh "${{ github.sha }}" "${{ github.repository }}" | tee report.md >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

Extends #566's arm64 tarball handoff to the amd64 and trusted build chains — the remaining `ttl.sh` references in `PR_multiarch.yml`.

`hadron-bios-amd64` and `hadron-trusted-amd64` push their images to `ttl.sh` only to hand them to a job on a different runner. Neither needs a registry for that: build with `load: true`, `docker save | gzip` into an artifact, `docker load` it back in the consumer. No credentials needed, so it also works on a pull request from a fork.

`toolchain-amd64` and `container-amd64` carried a `ttl.sh/` prefix on tags that were never actually pushed (no `push:`, or `load: true` only). Dropped for accuracy — no functional change, same as #566 did for the equivalent arm64 jobs.

## A third consumer #566 didn't have to deal with

`image-size-report-amd64` runs on its own runner and did a live `docker pull` from `ttl.sh` to compare the PR's images against the `:main` baseline for the size report. It now downloads the same four tarball artifacts the build jobs already produce, and `image-size-report.sh` checks local image presence instead of pulling.

Three of `hadron-bios-amd64`'s matrix combos and both of `hadron-trusted-amd64`'s now upload a tarball each — more than the two combos the build chains alone would need — because the size report needs the `default`-kernel variants too, which no other job in this file consumes.

## What is verified, and what is not

Verified: the YAML parses with all 20 jobs intact, no `ttl.sh` reference remains in the amd64/trusted jobs or in `image-size-report.sh`, and every producer/consumer artifact name pair matches (traced by hand, job by job).

**Not verified: this has never run.** Two things worth a reviewer's eye:

1. **`docker build` instead of buildx**, in `build-kairos-bios-amd64` and `build-kairos-trusted-amd64`. Matches #566's own finding: the buildx docker-container driver can't resolve a `FROM` against the local image store, so the base image (arriving as a loaded tarball, not a registry pull) needs a plain build.
2. **`image-size-report-amd64` downloads four artifacts individually by exact name**, not by glob pattern with `merge-multiple`. `actions/download-artifact`'s `pattern` input doesn't document multi-pattern matching, and a broad pattern would risk picking up the differently-named `hadron-init-*-image` artifacts from the build-kairos jobs too.

## Watch before merging

Per mauromorales/mission-control#282: `hadron-grub-arm64` and `build-kairos-grub-arm64`'s run times on the arm64 tarball path (#566) should be checked against their ttl.sh-era historical spread before trusting this shape at scale. This PR's own CI run is the amd64/trusted data point for the same question.

---

AI assisted this pull request. A human is attending and directed it.
