### PR TITLE
Show layer sysext artifacts on components page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,3 +285,4 @@ components: ## Generate components.json + components.md for the working tree
 test-components: ## Run the component-generator shell tests
 	sh ./hack/gen-components_test.sh
 	sh ./hack/gen-components_shipped_test.sh
+	node ./hack/components-template_test.js

--- a/hack/components-template.html
+++ b/hack/components-template.html
@@ -536,10 +536,17 @@
     var img=layer.image||'';
     (layer.tags||[]).forEach(function(t){
       var ref=img?(img+':'+t.tag):t.tag;
+      var sysextHtml='';
+      Object.keys(t.sysext||{}).sort().forEach(function(arch){
+        var sysextRef=(t.sysext[arch]||{}).oci||'';
+        if(!sysextRef) return;
+        sysextHtml+='<button class="tag-copy" data-copy="'+esc(sysextRef)+'" title="Copy '+esc(sysextRef)+'" aria-label="Copy '+esc(arch)+' sysext reference">'+esc(arch)+' sysext</button>';
+      });
       tagsHtml+='<div class="tag-row">'+
         '<span class="tag-name" title="'+esc(ref)+'">'+esc(t.tag)+'</span>'+
         '<span class="tag-date">'+esc(fmtDate(t.created))+'</span>'+
         '<button class="tag-copy" data-copy="'+esc(ref)+'" title="Copy '+esc(ref)+'" aria-label="Copy image reference">Copy</button>'+
+        sysextHtml+
       '</div>';
     });
     var openAttr=lyOpen[layer.name]?' open':'';

--- a/hack/components-template_test.js
+++ b/hack/components-template_test.js
@@ -1,0 +1,37 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+const template = fs.readFileSync(`${__dirname}/components-template.html`, 'utf8');
+const match = template.match(/function layerCard\(layer\)\{[\s\S]*?\n  \}\n  function layersRender/);
+assert(match, 'layerCard function not found in components template');
+
+const context = {
+  esc: value => String(value),
+  fmtDate: value => value,
+  lyOpen: {},
+};
+vm.createContext(context);
+vm.runInContext(`${match[0].replace(/\n  function layersRender$/, '')}; this.layerCard = layerCard;`, context);
+
+const html = context.layerCard({
+  name: 'git',
+  title: 'Git',
+  image: 'ghcr.io/kairos-io/hadron-layers/git',
+  latest: '2.55.0',
+  tags: [{
+    tag: '2.55.0',
+    created: '2026-08-18',
+    sysext: {
+      amd64: {oci: 'ghcr.io/kairos-io/hadron-layers/sysext/git@sha256:amd64'},
+      arm64: {oci: 'ghcr.io/kairos-io/hadron-layers/sysext/git@sha256:arm64'},
+    },
+  }],
+});
+
+assert.match(html, /amd64 sysext/);
+assert.match(html, /arm64 sysext/);
+assert.match(html, /data-copy="ghcr\.io\/kairos-io\/hadron-layers\/sysext\/git@sha256:amd64"/);
+assert.match(html, /data-copy="ghcr\.io\/kairos-io\/hadron-layers\/sysext\/git@sha256:arm64"/);
+
+console.log('components template sysext tests passed');


### PR DESCRIPTION
## Summary

- show architecture-specific sysext artifacts beside each layer version
- copy immutable, digest-pinned OCI references from the published layer index
- keep the existing layer image and tag controls unchanged

## Why

`hadron-layers` now publishes sysext references in `releases.json`. The Hadron components page already consumes that index but did not display the new artifacts.

## Verification

- `make test-components`
- `git diff --check`

Related to kairos-io/hadron-layers#48 and kairos-io/kairos#4298.