### PR TITLE
ci: pin the kairos Dockerfile fetch to a commit, not master

### DIFF
--- a/.github/workflows/PR_multiarch.yml
+++ b/.github/workflows/PR_multiarch.yml
@@ -17,6 +17,9 @@ env:
   # pr-cache-cleanup.yml when the PR closes.
   PR_CACHE_WRITE: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
   PR_NUM: ${{ github.event.pull_request.number }}
+  # Pinned commit, not a branch: see the matching comment on
+  # KAIROS_DOCKERFILE_REF in the Makefile. Keep the two in sync.
+  KAIROS_DOCKERFILE_REF: c2426c11c34198fcb50bfe4d43e827619292e26f
 
 jobs:
   # Ensure every ghcr source image the Dockerfile references is
@@ -555,7 +558,7 @@ jobs:
       - name: Download Dockerfile from kairos repository
         run: |
           mkdir -p build
-          curl -sSL https://raw.githubusercontent.com/kairos-io/kairos/master/images/Dockerfile -o build/Dockerfile.kairos
+          curl -sSL https://raw.githubusercontent.com/kairos-io/kairos/${{ env.KAIROS_DOCKERFILE_REF }}/images/Dockerfile -o build/Dockerfile.kairos
       - name: Build and push
         uses: docker/build-push-action@v7
         env:
@@ -615,7 +618,7 @@ jobs:
       - name: Download Dockerfile from kairos repository
         run: |
           mkdir -p build
-          curl -sSL https://raw.githubusercontent.com/kairos-io/kairos/master/images/Dockerfile -o build/Dockerfile.kairos
+          curl -sSL https://raw.githubusercontent.com/kairos-io/kairos/${{ env.KAIROS_DOCKERFILE_REF }}/images/Dockerfile -o build/Dockerfile.kairos
       - name: Build and push
         uses: docker/build-push-action@v7
         env:
@@ -980,7 +983,7 @@ jobs:
       - name: Download Dockerfile from kairos repository
         run: |
           mkdir -p build
-          curl -sSL https://raw.githubusercontent.com/kairos-io/kairos/master/images/Dockerfile -o build/Dockerfile.kairos
+          curl -sSL https://raw.githubusercontent.com/kairos-io/kairos/${{ env.KAIROS_DOCKERFILE_REF }}/images/Dockerfile -o build/Dockerfile.kairos
       # Plain docker build, not buildx. The buildx docker-container driver
       # cannot resolve a FROM against the local image store, and the base image
       # arrives here as a tarball rather than from a registry. This job is a

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,19 @@ PROGRESS_FLAG = --progress=${PROGRESS}
 KUBERNETES_DISTRO ?=
 KUBERNETES_VERSION ?= latest
 FIPS ?= "no-fips"
+# Pinned commit, not a branch: build-kairos fetches this file live at build
+# time, so leaving it on `master` means every hadron CI run depends on
+# whatever kairos/master happens to be at the moment it runs, not on
+# hadron's own diff. PR #564's CI went red on `reset tests` on 2026-08-13
+# from exactly this: kairos/master's ARG KAIROS_INIT moved between two
+# otherwise-identical PR runs on this repo, with zero hadron code change
+# in between. Bump deliberately, and only to a commit where kairos's own
+# CI (github.com/kairos-io/kairos/actions) is green — this SHA is the
+# commit before kairos merged 'feat/monorepo-kairos-init', whose Unit
+# tests job is currently red on a broken //go:embed pattern. Override
+# with `make build-kairos KAIROS_DOCKERFILE_REF=master` to test against
+# tip.
+KAIROS_DOCKERFILE_REF ?= c2426c11c34198fcb50bfe4d43e827619292e26f
 # Versions live in sources.yaml (single source of truth). Dockerfile is
 # generated from Dockerfile.tmpl by `make render`; both KERNEL_VERSION and
 # DWARVES_VERSION are read from sources.yaml so this Makefile does not
@@ -144,7 +157,7 @@ build-kairos:
 	@echo "Building Kairos image..."
 	@echo "Fetching Dockerfile from kairos repository..."
 	@mkdir -p build
-	@curl -sSL https://raw.githubusercontent.com/kairos-io/kairos/master/images/Dockerfile -o build/Dockerfile.kairos || (echo "Error: Failed to fetch Dockerfile from kairos repository" && exit 1)
+	@curl -sSL https://raw.githubusercontent.com/kairos-io/kairos/${KAIROS_DOCKERFILE_REF}/images/Dockerfile -o build/Dockerfile.kairos || (echo "Error: Failed to fetch Dockerfile from kairos repository" && exit 1)
 	@if [ "${BOOTLOADER}" = "systemd" ]; then \
   		TRUSTED_BOOT="true"; \
 	else \


### PR DESCRIPTION
doing this while the problem is on kairos master, we can remove later but I think it's better to have a pinned version than to be guessing what new thing broke 