### PR TITLE
ci+dockerfile: un-split hadron's riscv64 pipeline, drop the native runner

### DIFF
--- a/.github/workflows/PR_multiarch.yml
+++ b/.github/workflows/PR_multiarch.yml
@@ -502,18 +502,18 @@ jobs:
 
           # full-image bios / no-fips
           sh hack/gen-components.sh \
-            --shipped "stage2-merge full-image-merge-base full-image-merge-no-fips full-image-pre-grub full-image-pre-preset full-image-final" \
+            --shipped "stage2-merge full-image-merge-base full-image-merge-no-fips full-image-pre-grub full-image-final" \
             --format md --name full-image-bios-no-fips --out-dir /tmp/components
 
           # full-image bios / fips (openssl version swapped)
           sh hack/gen-components.sh \
-            --shipped "stage2-merge full-image-merge-base full-image-merge-fips full-image-pre-grub full-image-pre-preset full-image-final" \
+            --shipped "stage2-merge full-image-merge-base full-image-merge-fips full-image-pre-grub full-image-final" \
             --override openssl=OPENSSL_FIPS_VERSION \
             --format md --name full-image-bios-fips --out-dir /tmp/components
 
           # full-image trusted / no-fips
           sh hack/gen-components.sh \
-            --shipped "stage2-merge full-image-merge-base full-image-merge-no-fips full-image-pre-systemd full-image-pre-preset full-image-final" \
+            --shipped "stage2-merge full-image-merge-base full-image-merge-no-fips full-image-pre-systemd full-image-final" \
             --format md --name full-image-trusted --out-dir /tmp/components
 
           {

--- a/.github/workflows/PR_riscv64.yml
+++ b/.github/workflows/PR_riscv64.yml
@@ -9,18 +9,22 @@ concurrency:
   group: ci-image-riscv64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 
-# PR-only pipeline: split RISC-V build (x86+QEMU pre-preset, native finalize). No GHCR releases, no ISO.
+# PR-only pipeline: RISC-V build, entirely on x86+QEMU. No GHCR releases, no ISO.
 #
 # Dependency graph:
 #   stage0 → stage1 → rsync ─┬→ cmake ────────────────┐
-#                             ├→ kernel (cloud+default) ┤→ toolchain → container
-#                             ├→ systemd ─────────────┤       ↓
-#                             └→ python ────────────────┘  hadron-bios-warm (x86+QEMU, full-image-pre-preset)
-#                                                              ↓
-#                                                         hadron-bios (native riscv64, systemctl + default)
+#                             ├→ kernel (cloud+default) ┤→ toolchain → container → hadron-bios (x86+QEMU, default)
+#                             ├→ systemd ─────────────┤
+#                             └→ python ────────────────┘
 #
-# x86+QEMU builds full-image-pre-preset (~30–40 min with cache), pushes OCI to ttl.sh.
-# Native imports that image as build-context and only runs full-image-final onward.
+# Used to be split into hadron-bios-warm (x86+QEMU, stops before systemctl
+# preset-all) pushing an OCI image, then a native riscv64 runner importing it
+# to run preset-all onward — preset-all used to SIGSEGV under QEMU. Retested
+# 2026-08-13 with qemu-user 10.2.2: 21/21 clean runs, the failure this split
+# existed for no longer reproduces (see Dockerfile.tmpl's full-image-final
+# comment). hadron-bios now builds the whole `default` target in one job, on
+# the same x86+QEMU runners as everything else in this pipeline — no OCI
+# hand-off, no native riscv64 runner.
 
 env:
   CACHE_TO: mode=max,ignore-error=true,compression=zstd,compression-level=3,oci-mediatypes=true,image-manifest=true
@@ -541,8 +545,9 @@ jobs:
             ARCH=riscv64
             BUILD_ARCH=riscv64
 
-  # x86+QEMU through full-image-pre-preset (stops before systemctl). Push OCI for native handoff.
-  hadron-bios-warm:
+  # x86+QEMU, whole way through: builds default (which now includes what used
+  # to be the native-only preset-all step) in one job, no OCI hand-off.
+  hadron-bios:
     runs-on: oracle-vm-32cpu-128gb-x86-64
     needs: [container]
     timeout-minutes: 360
@@ -572,65 +577,6 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
-      - name: Build and push pre-preset image (${{ matrix.kernel }})
-        uses: docker/build-push-action@v7
-        env:
-          SOURCE_DATE_EPOCH: 0
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: ./
-          file: ./Dockerfile
-          platforms: linux/riscv64
-          push: true
-          tags: ttl.sh/hadron-pre-preset-riscv64${{ matrix.kernel == 'cloud' && '-cloud' || '' }}:${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
-          target: full-image-pre-preset
-          cache-from: |
-            type=registry,ref=quay.io/kairos/hadron-build-cache:stage0-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:stage1-merge-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:rsync-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:cmake-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:kernel-misc-${{ matrix.kernel }}-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:kernel-misc-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:systemd-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:python-build-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:toolchain-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:container-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:grub-pre-final-${{ matrix.kernel }}-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:grub-${{ matrix.kernel }}-riscv64,mode=max
-          cache-to: type=registry,ref=quay.io/kairos/hadron-build-cache:grub-pre-final-${{ matrix.kernel }}-riscv64,${{ env.CACHE_TO_MIN }}
-          build-args: |
-            BOOTLOADER=grub
-            KERNEL_TYPE=${{ matrix.kernel }}
-            ARCH=riscv64
-            BUILD_ARCH=riscv64
-
-  # Native riscv64: import pre-preset OCI, run systemctl + remainder, push default image.
-  hadron-bios:
-    runs-on: ubuntu-24.04-riscv
-    needs: [hadron-bios-warm]
-    timeout-minutes: 60
-    strategy:
-      max-parallel: 1
-      matrix:
-        kernel: [cloud, default]
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - name: Render Dockerfile
-        uses: ./.github/actions/render-dockerfile
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@master
-        with:
-          buildkitd-config-inline: |
-            [worker.oci]
-              max-parallelism = 4
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v6
       - name: Build and push default image (${{ matrix.kernel }})
         uses: docker/build-push-action@v7
         env:
@@ -645,8 +591,19 @@ jobs:
           tags: ttl.sh/hadron${{ matrix.kernel == 'cloud' && '-cloud' || '' }}-riscv64:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           target: default
-          build-contexts: |
-            full-image-pre-preset=docker-image://ttl.sh/hadron-pre-preset-riscv64${{ matrix.kernel == 'cloud' && '-cloud' || '' }}:${{ github.sha }}
+          cache-from: |
+            type=registry,ref=quay.io/kairos/hadron-build-cache:stage0-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:stage1-merge-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:rsync-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:cmake-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:kernel-misc-${{ matrix.kernel }}-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:kernel-misc-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:systemd-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:python-build-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:toolchain-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:container-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:grub-${{ matrix.kernel }}-riscv64,mode=max
+          cache-to: type=registry,ref=quay.io/kairos/hadron-build-cache:grub-${{ matrix.kernel }}-riscv64,${{ env.CACHE_TO_MIN }}
           build-args: |
             BOOTLOADER=grub
             KERNEL_TYPE=${{ matrix.kernel }}

--- a/.github/workflows/build-multiarch-images.yml
+++ b/.github/workflows/build-multiarch-images.yml
@@ -695,7 +695,9 @@ jobs:
   # ============================================================================
   # RISC-V 64-bit pipeline
   # ============================================================================
-  # x86+QEMU builds through full-image-pre-preset; native riscv64 finishes default.
+  # Entirely on x86+QEMU — see the un-split note on the hadron-bios-riscv64
+  # job below and Dockerfile.tmpl's full-image-final for why no native riscv64
+  # runner is needed any more.
   #
   # Dependency graph:
   #   stage0-riscv64 → stage1-riscv64 → rsync-riscv64 ─┬→ cmake-riscv64 ────────┐
@@ -703,9 +705,7 @@ jobs:
   #                                                     ├→ systemd-riscv64 ──────┤       ↓
   #                                                     └→ python-riscv64 ────────┘  container-riscv64
   #                                                                                        ↓
-  #                                                              hadron-bios-riscv64-warm (x86+QEMU)
-  #                                                                                        ↓
-  #                                                              hadron-bios-riscv64 (native)
+  #                                                                          hadron-bios-riscv64 (x86+QEMU)
 
   stage0-riscv64:
     if: ${{ false }}
@@ -1237,7 +1237,12 @@ jobs:
             ARCH=riscv64
             BUILD_ARCH=riscv64
 
-  hadron-bios-riscv64-warm:
+  # x86+QEMU, whole way through: builds default (which now includes what used
+  # to be the native-only preset-all step) in one job, no OCI hand-off. See
+  # the equivalent comment in PR_riscv64.yml and Dockerfile.tmpl's
+  # full-image-final for why the split (and the native riscv64 runner it
+  # needed) is gone.
+  hadron-bios-riscv64:
     runs-on: oracle-vm-32cpu-128gb-x86-64
     needs: [container-riscv64]
     timeout-minutes: 360
@@ -1279,76 +1284,6 @@ jobs:
         with:
           labels: |
             org.opencontainers.image.licenses=Apache-2.0
-      - name: Build and push pre-preset image (${{ matrix.kernel }})
-        uses: docker/build-push-action@v7
-        env:
-          SOURCE_DATE_EPOCH: 0
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: ./
-          file: ./Dockerfile
-          platforms: linux/riscv64
-          push: true
-          tags: ghcr.io/${{ github.repository }}-pre-preset-riscv64${{ matrix.kernel == 'cloud' && '-cloud' || '' }}:${{ github.ref_name }}
-          labels: ${{ steps.meta.outputs.labels }}
-          target: full-image-pre-preset
-          cache-from: |
-            type=registry,ref=quay.io/kairos/hadron-build-cache:stage0-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:stage1-merge-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:rsync-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:cmake-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:kernel-misc-${{ matrix.kernel }}-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:kernel-misc-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:systemd-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:python-build-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:toolchain-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:container-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:grub-pre-final-${{ matrix.kernel }}-riscv64,mode=max
-            type=registry,ref=quay.io/kairos/hadron-build-cache:grub-${{ matrix.kernel }}-riscv64,mode=max
-          cache-to: ${{ github.ref_name == 'main' && format('type=registry,ref=quay.io/kairos/hadron-build-cache:grub-pre-final-{0}-riscv64,{1}', matrix.kernel, env.CACHE_TO_MIN) || '' }}
-          build-args: |
-            BOOTLOADER=grub
-            KERNEL_TYPE=${{ matrix.kernel }}
-            ARCH=riscv64
-            BUILD_ARCH=riscv64
-
-  hadron-bios-riscv64:
-    runs-on: ubuntu-24.04-riscv
-    needs: [hadron-bios-riscv64-warm]
-    timeout-minutes: 60
-    strategy:
-      max-parallel: 1
-      matrix:
-        kernel: [cloud, default]
-    permissions:
-      packages: write
-      contents: read
-      attestations: write
-      id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - name: Render Dockerfile
-        uses: ./.github/actions/render-dockerfile
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@master
-        with:
-          buildkitd-config-inline: |
-            [worker.oci]
-              max-parallelism = 4
-      - name: Log in to the Container registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          labels: |
-            org.opencontainers.image.licenses=Apache-2.0
       - name: Build and push default image (${{ matrix.kernel }})
         uses: docker/build-push-action@v7
         env:
@@ -1362,8 +1297,19 @@ jobs:
           tags: ghcr.io/${{ github.repository }}${{ matrix.kernel == 'cloud' && '-cloud' || '' }}:${{ github.ref_name }}-riscv64
           labels: ${{ steps.meta.outputs.labels }}
           target: default
-          build-contexts: |
-            full-image-pre-preset=docker-image://ghcr.io/${{ github.repository }}-pre-preset-riscv64${{ matrix.kernel == 'cloud' && '-cloud' || '' }}:${{ github.ref_name }}
+          cache-from: |
+            type=registry,ref=quay.io/kairos/hadron-build-cache:stage0-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:stage1-merge-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:rsync-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:cmake-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:kernel-misc-${{ matrix.kernel }}-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:kernel-misc-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:systemd-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:python-build-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:toolchain-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:container-riscv64,mode=max
+            type=registry,ref=quay.io/kairos/hadron-build-cache:grub-${{ matrix.kernel }}-riscv64,mode=max
+          cache-to: ${{ github.ref_name == 'main' && format('type=registry,ref=quay.io/kairos/hadron-build-cache:grub-{0}-riscv64,{1}', matrix.kernel, env.CACHE_TO_MIN) || '' }}
           build-args: |
             VERSION=${{ env.VERSION }}
             BOOTLOADER=grub

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -3825,15 +3825,17 @@ FROM scratch AS full-image-systemd
 COPY --from=full-image-pre-systemd /skeleton /
 
 ## Final image depending on the bootloader
-# Split before systemctl preset-all: it was unreliable under QEMU (SIGSEGV), so CI
-# builds full-image-pre-preset on x86, pushes OCI, then native riscv64 imports it
-# via buildx --build-context full-image-pre-preset=docker-image://… for full-image-final.
-#
-# Retested 2026-08-13 with qemu-user 10.2.2: preset-all completed on 21/21 emulated
-# riscv64 runs (~0.9s each) and the whole `default` target built green under emulation.
-# The split is kept until CI is re-timed on stock runners, but the QEMU failure that
-# motivated it (8855153, ca32df5) no longer reproduces on a current QEMU.
-FROM full-image-${BOOTLOADER} AS full-image-pre-preset
+# Used to split here, before systemctl preset-all: that step was unreliable
+# under QEMU (SIGSEGV), so CI built this stage on x86, pushed it as an OCI
+# image, and a native riscv64 runner imported it via buildx --build-context
+# to run preset-all onward. Retested 2026-08-13 with qemu-user 10.2.2:
+# preset-all completed on 21/21 emulated riscv64 runs (~0.9s each) and the
+# whole `default` target built green under emulation — the QEMU failure that
+# motivated the split (8855153, ca32df5) no longer reproduces on a current
+# QEMU, so the split (and the native-runner dependency it existed for) is
+# gone. Everything through preset-all now runs in one stage, on x86 like the
+# rest of the pipeline.
+FROM full-image-${BOOTLOADER} AS full-image-final
 SHELL ["/bin/bash", "-c"]
 ARG VERSION
 ARG BUILD_ARCH
@@ -3890,12 +3892,8 @@ RUN busybox --install
 # mkfs.fat is a script that calls mkfs.vfat busybox applet with the proper name and pass all args for compatibility
 RUN echo -e '#!/bin/sh\nexec /bin/mkfs.vfat "$@"\n' > /bin/mkfs.fat && chmod +x /bin/mkfs.fat
 
-FROM full-image-pre-preset AS full-image-final
-SHELL ["/bin/bash", "-c"]
-ARG VERSION
-ARG BUILD_ARCH
-# preset all systemd services (runs natively on riscv64 in CI; see the note on
-# full-image-pre-preset — the QEMU crash no longer reproduces on qemu-user 10.2.2)
+# preset all systemd services (the QEMU crash that used to require running this
+# natively no longer reproduces on qemu-user 10.2.2 — see the note above)
 RUN systemctl preset-all
 # Disable systemd-make-policy as we don't use it and it conflicts with
 # measurements with PCR policies


### PR DESCRIPTION
## Why

The split around \`systemctl preset-all\` existed because that step was unreliable under QEMU (SIGSEGV), so CI built everything up to that point on x86, pushed it as an OCI image, and a native \`ubuntu-24.04-riscv\` runner — the only job in either riscv64 pipeline pinned to it — imported it via \`buildx --build-context\` to finish the build.

Retested 2026-08-13 with qemu-user 10.2.2 (evidence on [#67](https://github.com/mauromorales/mission-control/issues/67), for context — that's our internal tracking, not a hadron issue): \`preset-all\` completed on 21/21 emulated riscv64 runs, and the whole \`default\` target built green under emulation with zero code changes. The failure this split existed for no longer reproduces.

## What changed

- **\`Dockerfile.tmpl\`**: merged the \`full-image-pre-preset\` / \`full-image-final\` stage split back into one \`full-image-final\` stage. The RUN commands and their order are unchanged — only the artificial CI-only stage boundary goes away.
- **\`PR_riscv64.yml\` and \`build-multiarch-images.yml\`**: merged the paired \`*-warm\` (x86+QEMU) and native (\`ubuntu-24.04-riscv\`) jobs into a single job building \`target: default\` in one pass, on the same x86+QEMU runners the rest of each pipeline already uses. Dropped the OCI push/import hand-off entirely. Renamed the \`grub-pre-final-*-riscv64\` cache key to \`grub-*-riscv64\` — it's now the same complete-build cache key every other stage uses, not a partial one.
- **\`PR_multiarch.yml\`**: its component-versions-report \`--shipped\` lists named \`full-image-pre-preset\` (a stage name shared across all architectures, not riscv64-specific). Dropped it since the stage no longer exists — the tool skips unknown names silently, so this wasn't breaking anything, just stale.
- **Also fixed \`build-multiarch-images.yml\`'s riscv64 jobs**, even though they're not literally what this ticket named: same warm/native split, same disable mechanism (a single \`if: false\` on \`stage0-riscv64\` cascades to everything downstream via \`needs:\`), and left alone it would've been a landmine — referencing a Dockerfile stage that no longer exists — for whoever re-enables it later.

## What this does NOT do

**Nothing is re-enabled.** Every \`if: ${{ false }}\` gate (\`stage0\`, \`stage0-riscv64\`, \`populate-sources\`, \`check-kernel-configs\`) is untouched in both workflow files — this is a pure definitional fix while the pipeline stays fully disabled. Re-timing with a warm cache on a stock runner (the actual remaining open question before proposing re-enabling upstream) needs at least one real CI run, which needs a gate lifted for that run. That's a separate, deliberate decision — flagging it here rather than making it as part of this PR.

## Testing

- \`./hack/render.sh\` confirms the generated \`Dockerfile\` (gitignored) reflects the merge cleanly.
- All three touched workflow files parse as valid YAML.
- Full-repo sweep confirms no remaining references to the removed stage name or the old job names anywhere in the tree.
- **Could not build/boot-test locally in this session** — no Docker daemon reachable in this sandbox. The underlying claim (this exact RUN sequence builds clean under QEMU) was already validated end-to-end in the #67 investigation (1473/1473 steps, current \`main\` at the time); this change only removes the stage boundary and CI wiring around it, it doesn't touch the RUN commands themselves.