### PR TITLE
docs: point issue reporting at kairos-io/kairos

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Hadron delivers a minimal, trustworthy operating system built from the ground up
 
 Hadron is Engineered by [Spectro Cloud](https://www.spectrocloud.com) from the [Kairos](https://kairos.io) team.
 
+> **Found a bug, or want to request a feature?** Open it on
+> [kairos-io/kairos](https://github.com/kairos-io/kairos/issues), including
+> issues about this repository. Every Kairos issue lives in one place, so you
+> never have to work out which repository to file against.
+
 ### Why Hadron?
 
 - **Minimal & Lean**: Bare essentials only—no bloat, just what you need


### PR DESCRIPTION
Part of kairos-io/kairos#4364.

This repository has its Issues tab turned off, and the README does not say where to go instead. A user who wants to report a bug here finds nothing.

This adds one short note near the top of the README, pointing every report at kairos-io/kairos. The wording is the same in every repository this ticket touches, so the instruction reads identically wherever a user lands.

No behaviour changes. Documentation only.

_This pull request was opened with AI assistance. This is not an agent. Mauro used AI to help write it._
