### PR TITLE
docs: shorten the reporting banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,8 @@ Hadron delivers a minimal, trustworthy operating system built from the ground up
 
 Hadron is Engineered by [Spectro Cloud](https://www.spectrocloud.com) from the [Kairos](https://kairos.io) team.
 
-> **Found a bug, or want to request a feature?** Open it on
-> [kairos-io/kairos](https://github.com/kairos-io/kairos/issues), including
-> issues about this repository. Every Kairos issue lives in one place, so you
-> never have to work out which repository to file against.
+> **Found a bug?** Open it on [kairos-io/kairos](https://github.com/kairos-io/kairos/issues).
+> Every Kairos issue lives there, whichever repository it is about.
 
 ### Why Hadron?
 


### PR DESCRIPTION
Follow-up to the banner pull request that is already merged here.

Mauro asked for a shorter banner. The merged version repeated itself and repeated the link. This cuts it to two lines and one link.

Part of kairos-io/kairos#4364.

_This pull request was opened with AI assistance. This is not an agent. Mauro used AI to help write it._
