### PR TITLE
fix(stage0): pre-stage musl for mussel, stop hitting musl.libc.org

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -32,6 +32,11 @@ RUN apk update && \
     curl m4 xz texinfo bison gawk gzip zstd-dev coreutils bzip2 tar rsync \
     git coreutils findutils pax-utils binutils
 
+# The tarball mussel itself needs for its cross-toolchain build (see
+# stage0 below), cached the same way every other source in this
+# Dockerfile is -- so mussel never has to fetch musl.libc.org directly.
+FROM ghcr.io/kairos-io/hadron-sources/musl-toolchain:${MUSL_TOOLCHAIN_VERSION} AS musl-toolchain-download
+
 FROM alpine-base AS stage0
 
 ########################################################
@@ -57,6 +62,19 @@ RUN if [ "${ARCH}" = "aarch64" ] && [ "${BUILD_ARCH}" != "aarch64" ]; then echo 
 RUN if [ "${ARCH}" = "riscv64" ] && [ "${BUILD_ARCH}" != "riscv64" ]; then echo "For ARCH riscv64, BUILD_ARCH must be riscv64"; exit 1; fi
 
 RUN git clone https://github.com/firasuke/mussel.git && cd mussel && git checkout ${MUSSEL_VERSION} -b build
+
+# mussel's mpackage() only fetches a package if its tarball isn't
+# already present at sources/<name>/<name>-<version>.<ext> -- confirmed
+# from mussel's own source, not assumed. Pre-staging musl here at that
+# exact path means mussel skips the network fetch for it entirely,
+# instead of hitting musl.libc.org directly with no fallback (the actual
+# cause of stage0 failing -- musl.libc.org itself was unreachable, this
+# has nothing to do with riscv64). mussel's own musl_sum checksum still
+# runs against this file, unchanged from what every prior successful
+# build already verified.
+RUN mkdir -p mussel/sources/musl
+COPY --from=musl-toolchain-download /sources/downloads/musl-toolchain.tar.gz mussel/sources/musl/musl-1.2.5.tar.gz
+
 # mussel's script fetches binutils/gcc/gmp/mpc/mpfr from
 # ftpmirror.gnu.org, which is GNU's mirror-selecting rotator. That
 # rotator has been intermittently redirecting to mirror nodes that

--- a/sources.yaml
+++ b/sources.yaml
@@ -645,6 +645,24 @@ packages:
       - https://musl.libc.org/releases/musl-${version}.tar.gz
     filename: musl.tar.gz
 
+  # A second, separately-versioned entry, not a duplicate of `musl` above.
+  # This is what mussel (the vendored cross-toolchain builder in stage0,
+  # not the final rootfs) pins internally -- 1.2.5, not 1.2.6 -- and
+  # mussel's own musl_sum checksum, already the value every prior
+  # successful build has verified against. mussel fetches this straight
+  # from musl.libc.org itself with no fallback, which is what's actually
+  # failing (stage0 timing out on musl.libc.org, not on riscv64 at all).
+  # Cached here the same way as every other source in this file, then
+  # pre-staged into mussel's own source directory before it runs, so it
+  # never touches musl.libc.org directly. See stage0 in Dockerfile.tmpl.
+  musl-toolchain:
+    version: "1.2.5"
+    version_arg: MUSL_TOOLCHAIN_VERSION
+    sha256: a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4
+    urls:
+      - https://musl.libc.org/releases/musl-${version}.tar.gz
+    filename: musl-toolchain.tar.gz
+
   musl-fts:
     version: "1.2.7"
     version_arg: FTS_VERSION


### PR DESCRIPTION
## Summary

`stage0` has been failing — confirmed from the actual failing log ([run 32481600204](https://github.com/kairos-io/hadron/actions/runs/32481600204/job/96769005748)), this isn't riscv64-specific at all:

```
curl: (28) Failed to connect to musl.libc.org:443 after 133527 ms: Could not connect to server
```

mussel (the vendored cross-toolchain builder) fetches musl straight from `musl.libc.org` with no fallback. `binutils`/`gcc`/`gmp`/`mpc`/`mpfr` already got a mirror-redirect fix for the same class of problem (`ftpmirror.gnu.org`'s rotator serving broken mirrors, see the existing comment above the `sed` in `Dockerfile.tmpl`) — musl never did.

## What this does

Confirmed from mussel's own source (`mpackage()` in [firasuke/mussel](https://github.com/firasuke/mussel)) that it skips its network fetch entirely when the tarball is already present at the exact local path it expects.

- Adds a `musl-toolchain` entry to `sources.yaml` — a **second, separately-versioned entry**, not a duplicate of the existing `musl` one (which is pinned to `1.2.6` for a different consumer). mussel's own vendored pin is `1.2.5`, confirmed by reading the pinned `MUSSEL_VERSION` commit directly, and the checksum used is mussel's own already-verified `musl_sum` value — not a new one I'm introducing.
- Cached via the existing per-package source cache (`populate-sources` / `ghcr.io/kairos-io/hadron-sources`, from #553) the same way every other source in this Dockerfile already is.
- Pre-staged into mussel's own source directory (`mussel/sources/musl/musl-1.2.5.tar.gz`) before `./mussel` runs, so it never touches `musl.libc.org` directly at all.

Rendered clean via `hack/render.sh` — no unresolved placeholders.

## Not done here

`populate-sources` needs a real run to actually publish `ghcr.io/kairos-io/hadron-sources/musl-toolchain:1.2.5` before this is exercised for real — the `musl-toolchain` entry in `sources.yaml` is picked up automatically by that workflow's own discovery step, no separate registration needed, but the image doesn't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)