### PR TITLE
ci: run the multiarch build/test suite on main, not just on PRs

### DIFF
--- a/.github/workflows/PR_multiarch.yml
+++ b/.github/workflows/PR_multiarch.yml
@@ -4,6 +4,15 @@ name: 'PR build and test images (multiarch)'
 on:
   pull_request:
   workflow_dispatch:
+  # Give the reset/acceptance suite a signal on `main` independent of any
+  # pull request. Without this, a regression that lands via an unpinned
+  # upstream reference (see mission-control#121) or via a change that
+  # merges clean but breaks a run only intermittently has nowhere to show
+  # as "main is red" -- it can only ever show as "your unrelated PR is
+  # red", which teaches a contributor to distrust the check. Cadence is a
+  # starting point, not a fixed choice: adjust it to match runner capacity.
+  schedule:
+    - cron: '0 6 * * *'
 
 concurrency:
   group: ci-image-multiarch-${{ github.head_ref || github.ref }}-${{ github.repository }}


### PR DESCRIPTION
## What

Adds a `schedule` trigger (`0 6 * * *`, daily) to `PR_multiarch.yml`, alongside the existing `pull_request` and `workflow_dispatch` triggers. No other change.

## Why

The workflow has only ever triggered on `pull_request`. `main` gets no run of the reset/acceptance suite from any trigger, so there is no green run and no red run there — the suite has no signal on `main` at all.

The gap has a specific cost. When an upstream component that `hadron`'s build depends on regresses, the breakage cannot appear as "main is red." It can only appear on whichever pull request happens to run next, and that PR is usually unrelated to the actual cause. A contributor then debugs their own change for a failure they did not cause.

Measured case: a `renovate` PR bumping only a GitHub Action version failed the reset-test suite (2026-08-11), and [kairos-io/hadron#564](https://github.com/kairos-io/hadron/pull/564), which changed only comments, failed the same way (2026-08-13). Neither PR could have caused the failure. Full writeup: [mauromorales/mission-control#121](https://github.com/mauromorales/mission-control/issues/121) (private tracker, referenced for context only).

That specific case was a different bug (`kairos`'s `images/Dockerfile` was fetched unpinned at build time — fixed in [#571](https://github.com/kairos-io/hadron/pull/571)). This PR addresses the other half: even with the fetch pinned, nothing runs this suite against `main` on its own, so a future regression still has nowhere to show up except on an unrelated PR.

## Why a schedule, not a push trigger

A push to `main` only fires when `hadron` itself changes. The failure mode this fixes is an *upstream* dependency drifting with no `hadron` commit at all, so only a schedule (independent of whether `hadron` changed) gives the signal. Happy to add a `push: branches: [main]` trigger too if maintainers want both.

## Cadence

Daily (`0 6 * * *`) is a starting point, not a considered choice — the suite runs on self-hosted runners and takes roughly half an hour, so the right cadence is a call about runner capacity that only the maintainers can make. Change the cron expression, or drop this to weekly, as fits.

## What this does not do

Does not touch the `pull_request` trigger, any job logic, or caching. `PR_CACHE_WRITE`/`PR_NUM` are already `if`-guarded to no-op cleanly when there is no pull-request context (see the existing guard at the top of the file), so a scheduled run just skips cache writes and reads a cache miss on the per-PR tag, same as any non-repo-PR run does today.

---

*AI assisted: this PR was opened by an autonomous agent (`mauro-agent`) acting under Mauro Morales's direction, authored and committed under his identity per team convention — see the `Co-developed-by` trailer on the commit. He has not reviewed this diff yet; it is a draft for exactly that reason.*